### PR TITLE
Add: disabling toggle switch when connecting/disconnecting

### DIFF
--- a/Psiphon/ViewController.m
+++ b/Psiphon/ViewController.m
@@ -238,9 +238,18 @@
     statusLabel.text = [self getVPNStatusDescription];
     
     // Listening for NEVPNStatusDidChangeNotification
-    [[NSNotificationCenter defaultCenter] addObserverForName:NEVPNStatusDidChangeNotification object:_targetManager.connection queue:NSOperationQueue.mainQueue usingBlock:^(NSNotification * _Nonnull note) {
+    [[NSNotificationCenter defaultCenter] addObserverForName:NEVPNStatusDidChangeNotification
+      object:_targetManager.connection
+      queue:NSOperationQueue.mainQueue usingBlock:^(NSNotification * _Nonnull note) {
         
         NSLog(@"received NEVPNStatusDidChangeNotification %@", [self getVPNStatusDescription]);
+
+        if (self.targetManager.connection.status == NEVPNStatusConnecting
+          || self.targetManager.connection.status == NEVPNStatusDisconnecting) {
+            startStopToggle.enabled = FALSE;
+        } else {
+            startStopToggle.enabled = TRUE;
+        }
         statusLabel.text = [self getVPNStatusDescription];
         [startStopToggle setOn:[self isVPNActive]];
     }];


### PR DESCRIPTION
Toggling switch somewhat quickly seems to create multiple PsiphonVPN processes. The old process hangs around and is not killed until the phone is restarted. New processes silently fail to create a new tunnel.
Workaround: disable the UI toggle switch while the extension is Connecting or Disconnecting.

**UPDATE** This is not acceptable as some users might need to disconnect while in "connecting"  state.