### PR TITLE
Add mutex around FMDB sqlite operations

### DIFF
--- a/PsiphonVPN/PacketTunnelProvider.m
+++ b/PsiphonVPN/PacketTunnelProvider.m
@@ -152,7 +152,12 @@ static const double kDefaultLogTruncationInterval = 12 * 60 * 60; // 12 hours
 }
 
 - (void)sleepWithCompletionHandler:(void (^)(void))completionHandler {
+    // Wait until no DB call is in progress on any other thread...
+    [sharedDB lock];
+    // ...and then call the completion handler.
     completionHandler();
+    // TODO: at this point, are all other threads suspended? Should we defer the unlock until wake?
+    [sharedDB unlock];
 }
 
 - (void)wake {

--- a/Shared/PsiphonDataSharedDB.h
+++ b/Shared/PsiphonDataSharedDB.h
@@ -31,6 +31,8 @@
 
 @interface PsiphonDataSharedDB : NSObject
 - (id)initForAppGroupIdentifier:(NSString*)identifier;
+- (void)lock;
+- (void)unlock;
 - (BOOL)createDatabase;
 - (BOOL)clearDatabase;
 


### PR DESCRIPTION
- Purpose is to allow waiting for any database call in progress
  to complete before acknowledging sleep notification so as to
  prevent a 0xdead10cc exception (sleeping while holding an SQLite
  lock).

- Has side-effect of serializing FMDB calls.