### PR TITLE
Fix bug: transifex_pull was falling back to untranslated English

### DIFF
--- a/Shared/Strings/ar.lproj/Localizable.strings
+++ b/Shared/Strings/ar.lproj/Localizable.strings
@@ -1,13 +1,13 @@
-/* Text for button that tell users there will by a short video ad. */
+/*[UNTRANSLATED] Text for button that tell users there will by a short video ad. */
 "AD_LOADED" = "Watch a short video while we get ready to connect you";
 
-/* Text for app subtitle on main view. */
+/*[UNTRANSLATED] Text for app subtitle on main view. */
 "APP_SUB_TITLE_MAIN_VIEW" = "BEYOND BORDERS";
 
 /* Text for app title on main view. */
 "APP_TITLE_MAIN_VIEW" = "سايفون";
 
-/* Text showing the app version. The '%@' placeholder is the version number. So it will look like 'Version 2'. */
+/*[UNTRANSLATED] Text showing the app version. The '%@' placeholder is the version number. So it will look like 'Version 2'. */
 "APP_VERSION" = "Version %@";
 
 /* Text above change region button that allows user to select their desired server region */
@@ -30,20 +30,20 @@
 /* Description for the 'Mail not configured' message. (InAppSettingsKit) */
 "MAIL_NOT_CONFIGURED_DESC" = "إعدادات الجهاز لا تسمح إراسل البريد إلكتروني. الرجاء التحقق من إعدادات البريد الإلكتروني ضمن الإعدادات.";
 
-/* Alert title informing user there is no internet connection */
+/*[UNTRANSLATED] Alert title informing user there is no internet connection */
 "NO_INTERNET" = "No Internet Connection";
 
 /* Alert OK Button
    Alert OK Button. (InAppSettingsKit) */
 "OK_BUTTON" = "موافق";
 
-/* Alert message informing the user they should open the app to finish connecting to the VPN. */
+/*[UNTRANSLATED] Alert message informing the user they should open the app to finish connecting to the VPN. */
 "OPEN_PSIPHON_APP" = "Please open Psiphon app to finish connecting.";
 
 /* Title of the settings (aka preferences) view (InAppSettingsKit) */
 "SETTINGS_TITLE" = "الإعدادات";
 
-/* Alert message informing user to turn on their cellular data or wifi to connect to the internet */
+/*[UNTRANSLATED] Alert message informing user to turn on their cellular data or wifi to connect to the internet */
 "TURN_ON_DATE" = "Turn on cellular data or use Wi-Fi to access data.";
 
 /* Alert message informing user they have to open the app */
@@ -64,7 +64,7 @@
 /* Status when the VPN is in an invalid state. For example, if the user doesn't give permission for the VPN configuration to be installed, and therefore the Psiphon VPN can't even try to connect. */
 "VPN_STATUS_INVALID" = "غير متصل";
 
-/* Status when the VPN was connected to a Psiphon server, got disconnected unexpectedly, and is currently trying to reconnect */
+/*[UNTRANSLATED] Status when the VPN was connected to a Psiphon server, got disconnected unexpectedly, and is currently trying to reconnect */
 "VPN_STATUS_RECONNECTING" = "Reconnecting";
 
 /* Status when the VPN is restarting. */

--- a/Shared/Strings/az.lproj/Localizable.strings
+++ b/Shared/Strings/az.lproj/Localizable.strings
@@ -4,7 +4,7 @@
 /* Text for app subtitle on main view. */
 "APP_SUB_TITLE_MAIN_VIEW" = "SƏRHƏDLƏRİ AŞARAQ";
 
-/* Text for app title on main view. */
+/*[UNTRANSLATED] Text for app title on main view. */
 "APP_TITLE_MAIN_VIEW" = "PSIPHON";
 
 /* Text showing the app version. The '%@' placeholder is the version number. So it will look like 'Version 2'. */

--- a/Shared/Strings/be.lproj/Localizable.strings
+++ b/Shared/Strings/be.lproj/Localizable.strings
@@ -4,7 +4,7 @@
 /* Text for app subtitle on main view. */
 "APP_SUB_TITLE_MAIN_VIEW" = "ПА-НАД МЕЖАМІ";
 
-/* Text for app title on main view. */
+/*[UNTRANSLATED] Text for app title on main view. */
 "APP_TITLE_MAIN_VIEW" = "PSIPHON";
 
 /* Text showing the app version. The '%@' placeholder is the version number. So it will look like 'Version 2'. */
@@ -33,7 +33,7 @@
 /* Alert title informing user there is no internet connection */
 "NO_INTERNET" = "Няма інтэрнэт злучэння";
 
-/* Alert OK Button
+/*[UNTRANSLATED] Alert OK Button
    Alert OK Button. (InAppSettingsKit) */
 "OK_BUTTON" = "OK";
 

--- a/Shared/Strings/bo.lproj/Localizable.strings
+++ b/Shared/Strings/bo.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-/* Text for button that tell users there will by a short video ad. */
+/*[UNTRANSLATED] Text for button that tell users there will by a short video ad. */
 "AD_LOADED" = "Watch a short video while we get ready to connect you";
 
 /* Text for app subtitle on main view. */
@@ -7,7 +7,7 @@
 /* Text for app title on main view. */
 "APP_TITLE_MAIN_VIEW" = "སཡི་ཕོན།";
 
-/* Text showing the app version. The '%@' placeholder is the version number. So it will look like 'Version 2'. */
+/*[UNTRANSLATED] Text showing the app version. The '%@' placeholder is the version number. So it will look like 'Version 2'. */
 "APP_VERSION" = "Version %@";
 
 /* Text above change region button that allows user to select their desired server region */
@@ -18,7 +18,7 @@
    Title of the button that dismisses the settings menu (InAppSettingsKit) */
 "DONE_ACTION" = "ཚར་སོང་།";
 
-/* Text displayed while app loads */
+/*[UNTRANSLATED] Text displayed while app loads */
 "LOADING" = "Loading...";
 
 /* Log view title bar text */
@@ -30,20 +30,20 @@
 /* Description for the 'Mail not configured' message. (InAppSettingsKit) */
 "MAIL_NOT_CONFIGURED_DESC" = "ཡོ་བྱད་འདི་གློག་འཕྲིན་གཏོང་བ་རྒྱུར་སྡེབ་སྒྲིབ་བྱེད་མིན་འདུག ཁྱེད་ཀྱིས་མཉེན་ཆས་སྒྲིབ་བཀོད་ནང་ནསགློག་འཕྲིན་སྒྲིག་བཀོད་སྡེབ་སྒྲིབ་གནང་རོགས།";
 
-/* Alert title informing user there is no internet connection */
+/*[UNTRANSLATED] Alert title informing user there is no internet connection */
 "NO_INTERNET" = "No Internet Connection";
 
-/* Alert OK Button
+/*[UNTRANSLATED] Alert OK Button
    Alert OK Button. (InAppSettingsKit) */
 "OK_BUTTON" = "OK";
 
-/* Alert message informing the user they should open the app to finish connecting to the VPN. */
+/*[UNTRANSLATED] Alert message informing the user they should open the app to finish connecting to the VPN. */
 "OPEN_PSIPHON_APP" = "Please open Psiphon app to finish connecting.";
 
-/* Title of the settings (aka preferences) view (InAppSettingsKit) */
+/*[UNTRANSLATED] Title of the settings (aka preferences) view (InAppSettingsKit) */
 "SETTINGS_TITLE" = "Settings";
 
-/* Alert message informing user to turn on their cellular data or wifi to connect to the internet */
+/*[UNTRANSLATED] Alert message informing user to turn on their cellular data or wifi to connect to the internet */
 "TURN_ON_DATE" = "Turn on cellular data or use Wi-Fi to access data.";
 
 /* Alert message informing user they have to open the app */
@@ -64,9 +64,9 @@
 /* Status when the VPN is in an invalid state. For example, if the user doesn't give permission for the VPN configuration to be installed, and therefore the Psiphon VPN can't even try to connect. */
 "VPN_STATUS_INVALID" = "མཐུད་མཚམས་བཞག";
 
-/* Status when the VPN was connected to a Psiphon server, got disconnected unexpectedly, and is currently trying to reconnect */
+/*[UNTRANSLATED] Status when the VPN was connected to a Psiphon server, got disconnected unexpectedly, and is currently trying to reconnect */
 "VPN_STATUS_RECONNECTING" = "Reconnecting";
 
-/* Status when the VPN is restarting. */
+/*[UNTRANSLATED] Status when the VPN is restarting. */
 "VPN_STATUS_RESTARTING" = "Restarting";
 

--- a/Shared/Strings/de.lproj/Localizable.strings
+++ b/Shared/Strings/de.lproj/Localizable.strings
@@ -4,10 +4,10 @@
 /* Text for app subtitle on main view. */
 "APP_SUB_TITLE_MAIN_VIEW" = "JENSEITS DER GRENZEN";
 
-/* Text for app title on main view. */
+/*[UNTRANSLATED] Text for app title on main view. */
 "APP_TITLE_MAIN_VIEW" = "PSIPHON";
 
-/* Text showing the app version. The '%@' placeholder is the version number. So it will look like 'Version 2'. */
+/*[UNTRANSLATED] Text showing the app version. The '%@' placeholder is the version number. So it will look like 'Version 2'. */
 "APP_VERSION" = "Version %@";
 
 /* Text above change region button that allows user to select their desired server region */
@@ -33,7 +33,7 @@
 /* Alert title informing user there is no internet connection */
 "NO_INTERNET" = "Keine Internetverbindung";
 
-/* Alert OK Button
+/*[UNTRANSLATED] Alert OK Button
    Alert OK Button. (InAppSettingsKit) */
 "OK_BUTTON" = "OK";
 

--- a/Shared/Strings/el.lproj/Localizable.strings
+++ b/Shared/Strings/el.lproj/Localizable.strings
@@ -4,7 +4,7 @@
 /* Text for app subtitle on main view. */
 "APP_SUB_TITLE_MAIN_VIEW" = "ΠΕΡΑ ΑΠΟ ΤΑ ΣΥΝΟΡΑ";
 
-/* Text for app title on main view. */
+/*[UNTRANSLATED] Text for app title on main view. */
 "APP_TITLE_MAIN_VIEW" = "PSIPHON";
 
 /* Text showing the app version. The '%@' placeholder is the version number. So it will look like 'Version 2'. */
@@ -24,16 +24,16 @@
 /* Log view title bar text */
 "LOGS_TITLE" = "Αρχεία καταγραφής";
 
-/* Shown when the device is not configured for sending email. (InAppSettingsKit) */
+/*[UNTRANSLATED] Shown when the device is not configured for sending email. (InAppSettingsKit) */
 "MAIL_NOT_CONFIGURED" = "Mail not configured";
 
-/* Description for the 'Mail not configured' message. (InAppSettingsKit) */
+/*[UNTRANSLATED] Description for the 'Mail not configured' message. (InAppSettingsKit) */
 "MAIL_NOT_CONFIGURED_DESC" = "This device is not configured for sending Email. Please configure the Mail settings in the Settings app.";
 
 /* Alert title informing user there is no internet connection */
 "NO_INTERNET" = "Δεν υπάρχει σύνδεση στο Internet";
 
-/* Alert OK Button
+/*[UNTRANSLATED] Alert OK Button
    Alert OK Button. (InAppSettingsKit) */
 "OK_BUTTON" = "OK";
 
@@ -43,7 +43,7 @@
 /* Title of the settings (aka preferences) view (InAppSettingsKit) */
 "SETTINGS_TITLE" = "Ρυθμίσεις";
 
-/* Alert message informing user to turn on their cellular data or wifi to connect to the internet */
+/*[UNTRANSLATED] Alert message informing user to turn on their cellular data or wifi to connect to the internet */
 "TURN_ON_DATE" = "Turn on cellular data or use Wi-Fi to access data.";
 
 /* Alert message informing user they have to open the app */

--- a/Shared/Strings/es.lproj/Localizable.strings
+++ b/Shared/Strings/es.lproj/Localizable.strings
@@ -4,7 +4,7 @@
 /* Text for app subtitle on main view. */
 "APP_SUB_TITLE_MAIN_VIEW" = "ATRAVESANDO FRONTERAS";
 
-/* Text for app title on main view. */
+/*[UNTRANSLATED] Text for app title on main view. */
 "APP_TITLE_MAIN_VIEW" = "PSIPHON";
 
 /* Text showing the app version. The '%@' placeholder is the version number. So it will look like 'Version 2'. */
@@ -33,7 +33,7 @@
 /* Alert title informing user there is no internet connection */
 "NO_INTERNET" = "No hay conexión a Internet";
 
-/* Alert OK Button
+/*[UNTRANSLATED] Alert OK Button
    Alert OK Button. (InAppSettingsKit) */
 "OK_BUTTON" = "OK";
 

--- a/Shared/Strings/fi.lproj/Localizable.strings
+++ b/Shared/Strings/fi.lproj/Localizable.strings
@@ -1,16 +1,16 @@
-/* Text for button that tell users there will by a short video ad. */
+/*[UNTRANSLATED] Text for button that tell users there will by a short video ad. */
 "AD_LOADED" = "Watch a short video while we get ready to connect you";
 
-/* Text for app subtitle on main view. */
+/*[UNTRANSLATED] Text for app subtitle on main view. */
 "APP_SUB_TITLE_MAIN_VIEW" = "BEYOND BORDERS";
 
-/* Text for app title on main view. */
+/*[UNTRANSLATED] Text for app title on main view. */
 "APP_TITLE_MAIN_VIEW" = "PSIPHON";
 
-/* Text showing the app version. The '%@' placeholder is the version number. So it will look like 'Version 2'. */
+/*[UNTRANSLATED] Text showing the app version. The '%@' placeholder is the version number. So it will look like 'Version 2'. */
 "APP_VERSION" = "Version %@";
 
-/* Text above change region button that allows user to select their desired server region */
+/*[UNTRANSLATED] Text above change region button that allows user to select their desired server region */
 "CHANGE_REGION" = "Change Region";
 
 /* Done button in navigation bar
@@ -18,32 +18,32 @@
    Title of the button that dismisses the settings menu (InAppSettingsKit) */
 "DONE_ACTION" = "Valmis";
 
-/* Text displayed while app loads */
+/*[UNTRANSLATED] Text displayed while app loads */
 "LOADING" = "Loading...";
 
 /* Log view title bar text */
 "LOGS_TITLE" = "Logitiedostot";
 
-/* Shown when the device is not configured for sending email. (InAppSettingsKit) */
+/*[UNTRANSLATED] Shown when the device is not configured for sending email. (InAppSettingsKit) */
 "MAIL_NOT_CONFIGURED" = "Mail not configured";
 
-/* Description for the 'Mail not configured' message. (InAppSettingsKit) */
+/*[UNTRANSLATED] Description for the 'Mail not configured' message. (InAppSettingsKit) */
 "MAIL_NOT_CONFIGURED_DESC" = "This device is not configured for sending Email. Please configure the Mail settings in the Settings app.";
 
-/* Alert title informing user there is no internet connection */
+/*[UNTRANSLATED] Alert title informing user there is no internet connection */
 "NO_INTERNET" = "No Internet Connection";
 
 /* Alert OK Button
    Alert OK Button. (InAppSettingsKit) */
 "OK_BUTTON" = "Valmis";
 
-/* Alert message informing the user they should open the app to finish connecting to the VPN. */
+/*[UNTRANSLATED] Alert message informing the user they should open the app to finish connecting to the VPN. */
 "OPEN_PSIPHON_APP" = "Please open Psiphon app to finish connecting.";
 
 /* Title of the settings (aka preferences) view (InAppSettingsKit) */
 "SETTINGS_TITLE" = "Asetukset";
 
-/* Alert message informing user to turn on their cellular data or wifi to connect to the internet */
+/*[UNTRANSLATED] Alert message informing user to turn on their cellular data or wifi to connect to the internet */
 "TURN_ON_DATE" = "Turn on cellular data or use Wi-Fi to access data.";
 
 /* Alert message informing user they have to open the app */
@@ -52,21 +52,21 @@
 /* Status when the VPN is connected to a Psiphon server */
 "VPN_STATUS_CONNECTED" = "Yhdistetty";
 
-/* Status when the VPN is connecting; that is, trying to connect to a Psiphon server */
+/*[UNTRANSLATED] Status when the VPN is connecting; that is, trying to connect to a Psiphon server */
 "VPN_STATUS_CONNECTING" = "Connecting";
 
 /* Status when the VPN is not connected to a Psiphon server, not trying to connect, and not in an error state */
 "VPN_STATUS_DISCONNECTED" = "Yhteys katkaistu";
 
-/* Status when the VPN is disconnecting. Sometimes going from connected to disconnected can take some time, and this is that state. */
+/*[UNTRANSLATED] Status when the VPN is disconnecting. Sometimes going from connected to disconnected can take some time, and this is that state. */
 "VPN_STATUS_DISCONNECTING" = "Disconnecting";
 
 /* Status when the VPN is in an invalid state. For example, if the user doesn't give permission for the VPN configuration to be installed, and therefore the Psiphon VPN can't even try to connect. */
 "VPN_STATUS_INVALID" = "Yhteys katkaistu";
 
-/* Status when the VPN was connected to a Psiphon server, got disconnected unexpectedly, and is currently trying to reconnect */
+/*[UNTRANSLATED] Status when the VPN was connected to a Psiphon server, got disconnected unexpectedly, and is currently trying to reconnect */
 "VPN_STATUS_RECONNECTING" = "Reconnecting";
 
-/* Status when the VPN is restarting. */
+/*[UNTRANSLATED] Status when the VPN is restarting. */
 "VPN_STATUS_RESTARTING" = "Restarting";
 

--- a/Shared/Strings/fr.lproj/Localizable.strings
+++ b/Shared/Strings/fr.lproj/Localizable.strings
@@ -4,10 +4,10 @@
 /* Text for app subtitle on main view. */
 "APP_SUB_TITLE_MAIN_VIEW" = "PAR-DELÀ LES FRONTIÈRES";
 
-/* Text for app title on main view. */
+/*[UNTRANSLATED] Text for app title on main view. */
 "APP_TITLE_MAIN_VIEW" = "PSIPHON";
 
-/* Text showing the app version. The '%@' placeholder is the version number. So it will look like 'Version 2'. */
+/*[UNTRANSLATED] Text showing the app version. The '%@' placeholder is the version number. So it will look like 'Version 2'. */
 "APP_VERSION" = "Version %@";
 
 /* Text above change region button that allows user to select their desired server region */
@@ -33,7 +33,7 @@
 /* Alert title informing user there is no internet connection */
 "NO_INTERNET" = "Aucune connexion Internet";
 
-/* Alert OK Button
+/*[UNTRANSLATED] Alert OK Button
    Alert OK Button. (InAppSettingsKit) */
 "OK_BUTTON" = "OK";
 

--- a/Shared/Strings/hr.lproj/Localizable.strings
+++ b/Shared/Strings/hr.lproj/Localizable.strings
@@ -1,13 +1,13 @@
-/* Text for button that tell users there will by a short video ad. */
+/*[UNTRANSLATED] Text for button that tell users there will by a short video ad. */
 "AD_LOADED" = "Watch a short video while we get ready to connect you";
 
-/* Text for app subtitle on main view. */
+/*[UNTRANSLATED] Text for app subtitle on main view. */
 "APP_SUB_TITLE_MAIN_VIEW" = "BEYOND BORDERS";
 
-/* Text for app title on main view. */
+/*[UNTRANSLATED] Text for app title on main view. */
 "APP_TITLE_MAIN_VIEW" = "PSIPHON";
 
-/* Text showing the app version. The '%@' placeholder is the version number. So it will look like 'Version 2'. */
+/*[UNTRANSLATED] Text showing the app version. The '%@' placeholder is the version number. So it will look like 'Version 2'. */
 "APP_VERSION" = "Version %@";
 
 /* Text above change region button that allows user to select their desired server region */
@@ -18,7 +18,7 @@
    Title of the button that dismisses the settings menu (InAppSettingsKit) */
 "DONE_ACTION" = "Gotovo";
 
-/* Text displayed while app loads */
+/*[UNTRANSLATED] Text displayed while app loads */
 "LOADING" = "Loading...";
 
 /* Log view title bar text */
@@ -30,20 +30,20 @@
 /* Description for the 'Mail not configured' message. (InAppSettingsKit) */
 "MAIL_NOT_CONFIGURED_DESC" = "Ovaj uređaj nije konfiguriran za slanje maila. Molimo konfigurirajte postavke maila u aplikaciji za postavke.";
 
-/* Alert title informing user there is no internet connection */
+/*[UNTRANSLATED] Alert title informing user there is no internet connection */
 "NO_INTERNET" = "No Internet Connection";
 
-/* Alert OK Button
+/*[UNTRANSLATED] Alert OK Button
    Alert OK Button. (InAppSettingsKit) */
 "OK_BUTTON" = "OK";
 
-/* Alert message informing the user they should open the app to finish connecting to the VPN. */
+/*[UNTRANSLATED] Alert message informing the user they should open the app to finish connecting to the VPN. */
 "OPEN_PSIPHON_APP" = "Please open Psiphon app to finish connecting.";
 
 /* Title of the settings (aka preferences) view (InAppSettingsKit) */
 "SETTINGS_TITLE" = "Postavke";
 
-/* Alert message informing user to turn on their cellular data or wifi to connect to the internet */
+/*[UNTRANSLATED] Alert message informing user to turn on their cellular data or wifi to connect to the internet */
 "TURN_ON_DATE" = "Turn on cellular data or use Wi-Fi to access data.";
 
 /* Alert message informing user they have to open the app */
@@ -67,6 +67,6 @@
 /* Status when the VPN was connected to a Psiphon server, got disconnected unexpectedly, and is currently trying to reconnect */
 "VPN_STATUS_RECONNECTING" = "Ponovo povezujem";
 
-/* Status when the VPN is restarting. */
+/*[UNTRANSLATED] Status when the VPN is restarting. */
 "VPN_STATUS_RESTARTING" = "Restarting";
 

--- a/Shared/Strings/id.lproj/Localizable.strings
+++ b/Shared/Strings/id.lproj/Localizable.strings
@@ -1,16 +1,16 @@
-/* Text for button that tell users there will by a short video ad. */
+/*[UNTRANSLATED] Text for button that tell users there will by a short video ad. */
 "AD_LOADED" = "Watch a short video while we get ready to connect you";
 
-/* Text for app subtitle on main view. */
+/*[UNTRANSLATED] Text for app subtitle on main view. */
 "APP_SUB_TITLE_MAIN_VIEW" = "BEYOND BORDERS";
 
-/* Text for app title on main view. */
+/*[UNTRANSLATED] Text for app title on main view. */
 "APP_TITLE_MAIN_VIEW" = "PSIPHON";
 
-/* Text showing the app version. The '%@' placeholder is the version number. So it will look like 'Version 2'. */
+/*[UNTRANSLATED] Text showing the app version. The '%@' placeholder is the version number. So it will look like 'Version 2'. */
 "APP_VERSION" = "Version %@";
 
-/* Text above change region button that allows user to select their desired server region */
+/*[UNTRANSLATED] Text above change region button that allows user to select their desired server region */
 "CHANGE_REGION" = "Change Region";
 
 /* Done button in navigation bar
@@ -18,7 +18,7 @@
    Title of the button that dismisses the settings menu (InAppSettingsKit) */
 "DONE_ACTION" = "Selesai";
 
-/* Text displayed while app loads */
+/*[UNTRANSLATED] Text displayed while app loads */
 "LOADING" = "Loading...";
 
 /* Log view title bar text */
@@ -30,20 +30,20 @@
 /* Description for the 'Mail not configured' message. (InAppSettingsKit) */
 "MAIL_NOT_CONFIGURED_DESC" = "Perangkat ini tidak dikonfigurasi untuk mengirim Email. Konfigurasikan pengaturan Mail di aplikasi Settings.";
 
-/* Alert title informing user there is no internet connection */
+/*[UNTRANSLATED] Alert title informing user there is no internet connection */
 "NO_INTERNET" = "No Internet Connection";
 
 /* Alert OK Button
    Alert OK Button. (InAppSettingsKit) */
 "OK_BUTTON" = "OKE";
 
-/* Alert message informing the user they should open the app to finish connecting to the VPN. */
+/*[UNTRANSLATED] Alert message informing the user they should open the app to finish connecting to the VPN. */
 "OPEN_PSIPHON_APP" = "Please open Psiphon app to finish connecting.";
 
 /* Title of the settings (aka preferences) view (InAppSettingsKit) */
 "SETTINGS_TITLE" = "Pengaturan";
 
-/* Alert message informing user to turn on their cellular data or wifi to connect to the internet */
+/*[UNTRANSLATED] Alert message informing user to turn on their cellular data or wifi to connect to the internet */
 "TURN_ON_DATE" = "Turn on cellular data or use Wi-Fi to access data.";
 
 /* Alert message informing user they have to open the app */
@@ -64,7 +64,7 @@
 /* Status when the VPN is in an invalid state. For example, if the user doesn't give permission for the VPN configuration to be installed, and therefore the Psiphon VPN can't even try to connect. */
 "VPN_STATUS_INVALID" = "Terputus";
 
-/* Status when the VPN was connected to a Psiphon server, got disconnected unexpectedly, and is currently trying to reconnect */
+/*[UNTRANSLATED] Status when the VPN was connected to a Psiphon server, got disconnected unexpectedly, and is currently trying to reconnect */
 "VPN_STATUS_RECONNECTING" = "Reconnecting";
 
 /* Status when the VPN is restarting. */

--- a/Shared/Strings/kk.lproj/Localizable.strings
+++ b/Shared/Strings/kk.lproj/Localizable.strings
@@ -4,7 +4,7 @@
 /* Text for app subtitle on main view. */
 "APP_SUB_TITLE_MAIN_VIEW" = "ШЕКАРАЛАРСЫЗ";
 
-/* Text for app title on main view. */
+/*[UNTRANSLATED] Text for app title on main view. */
 "APP_TITLE_MAIN_VIEW" = "PSIPHON";
 
 /* Text showing the app version. The '%@' placeholder is the version number. So it will look like 'Version 2'. */

--- a/Shared/Strings/km.lproj/Localizable.strings
+++ b/Shared/Strings/km.lproj/Localizable.strings
@@ -4,7 +4,7 @@
 /* Text for app subtitle on main view. */
 "APP_SUB_TITLE_MAIN_VIEW" = "លើសព្រំដែន";
 
-/* Text for app title on main view. */
+/*[UNTRANSLATED] Text for app title on main view. */
 "APP_TITLE_MAIN_VIEW" = "PSIPHON";
 
 /* Text showing the app version. The '%@' placeholder is the version number. So it will look like 'Version 2'. */

--- a/Shared/Strings/ko.lproj/Localizable.strings
+++ b/Shared/Strings/ko.lproj/Localizable.strings
@@ -1,16 +1,16 @@
-/* Text for button that tell users there will by a short video ad. */
+/*[UNTRANSLATED] Text for button that tell users there will by a short video ad. */
 "AD_LOADED" = "Watch a short video while we get ready to connect you";
 
-/* Text for app subtitle on main view. */
+/*[UNTRANSLATED] Text for app subtitle on main view. */
 "APP_SUB_TITLE_MAIN_VIEW" = "BEYOND BORDERS";
 
-/* Text for app title on main view. */
+/*[UNTRANSLATED] Text for app title on main view. */
 "APP_TITLE_MAIN_VIEW" = "PSIPHON";
 
-/* Text showing the app version. The '%@' placeholder is the version number. So it will look like 'Version 2'. */
+/*[UNTRANSLATED] Text showing the app version. The '%@' placeholder is the version number. So it will look like 'Version 2'. */
 "APP_VERSION" = "Version %@";
 
-/* Text above change region button that allows user to select their desired server region */
+/*[UNTRANSLATED] Text above change region button that allows user to select their desired server region */
 "CHANGE_REGION" = "Change Region";
 
 /* Done button in navigation bar
@@ -18,32 +18,32 @@
    Title of the button that dismisses the settings menu (InAppSettingsKit) */
 "DONE_ACTION" = "완료";
 
-/* Text displayed while app loads */
+/*[UNTRANSLATED] Text displayed while app loads */
 "LOADING" = "Loading...";
 
 /* Log view title bar text */
 "LOGS_TITLE" = "로그";
 
-/* Shown when the device is not configured for sending email. (InAppSettingsKit) */
+/*[UNTRANSLATED] Shown when the device is not configured for sending email. (InAppSettingsKit) */
 "MAIL_NOT_CONFIGURED" = "Mail not configured";
 
-/* Description for the 'Mail not configured' message. (InAppSettingsKit) */
+/*[UNTRANSLATED] Description for the 'Mail not configured' message. (InAppSettingsKit) */
 "MAIL_NOT_CONFIGURED_DESC" = "This device is not configured for sending Email. Please configure the Mail settings in the Settings app.";
 
-/* Alert title informing user there is no internet connection */
+/*[UNTRANSLATED] Alert title informing user there is no internet connection */
 "NO_INTERNET" = "No Internet Connection";
 
 /* Alert OK Button
    Alert OK Button. (InAppSettingsKit) */
 "OK_BUTTON" = "확인";
 
-/* Alert message informing the user they should open the app to finish connecting to the VPN. */
+/*[UNTRANSLATED] Alert message informing the user they should open the app to finish connecting to the VPN. */
 "OPEN_PSIPHON_APP" = "Please open Psiphon app to finish connecting.";
 
-/* Title of the settings (aka preferences) view (InAppSettingsKit) */
+/*[UNTRANSLATED] Title of the settings (aka preferences) view (InAppSettingsKit) */
 "SETTINGS_TITLE" = "Settings";
 
-/* Alert message informing user to turn on their cellular data or wifi to connect to the internet */
+/*[UNTRANSLATED] Alert message informing user to turn on their cellular data or wifi to connect to the internet */
 "TURN_ON_DATE" = "Turn on cellular data or use Wi-Fi to access data.";
 
 /* Alert message informing user they have to open the app */
@@ -64,7 +64,7 @@
 /* Status when the VPN is in an invalid state. For example, if the user doesn't give permission for the VPN configuration to be installed, and therefore the Psiphon VPN can't even try to connect. */
 "VPN_STATUS_INVALID" = "연결 해제";
 
-/* Status when the VPN was connected to a Psiphon server, got disconnected unexpectedly, and is currently trying to reconnect */
+/*[UNTRANSLATED] Status when the VPN was connected to a Psiphon server, got disconnected unexpectedly, and is currently trying to reconnect */
 "VPN_STATUS_RECONNECTING" = "Reconnecting";
 
 /* Status when the VPN is restarting. */

--- a/Shared/Strings/ky.lproj/Localizable.strings
+++ b/Shared/Strings/ky.lproj/Localizable.strings
@@ -4,7 +4,7 @@
 /* Text for app subtitle on main view. */
 "APP_SUB_TITLE_MAIN_VIEW" = "ЧЕК АРАЛАРСЫЗ";
 
-/* Text for app title on main view. */
+/*[UNTRANSLATED] Text for app title on main view. */
 "APP_TITLE_MAIN_VIEW" = "PSIPHON";
 
 /* Text showing the app version. The '%@' placeholder is the version number. So it will look like 'Version 2'. */

--- a/Shared/Strings/my.lproj/Localizable.strings
+++ b/Shared/Strings/my.lproj/Localizable.strings
@@ -1,13 +1,13 @@
-/* Text for button that tell users there will by a short video ad. */
+/*[UNTRANSLATED] Text for button that tell users there will by a short video ad. */
 "AD_LOADED" = "Watch a short video while we get ready to connect you";
 
-/* Text for app subtitle on main view. */
+/*[UNTRANSLATED] Text for app subtitle on main view. */
 "APP_SUB_TITLE_MAIN_VIEW" = "BEYOND BORDERS";
 
-/* Text for app title on main view. */
+/*[UNTRANSLATED] Text for app title on main view. */
 "APP_TITLE_MAIN_VIEW" = "PSIPHON";
 
-/* Text showing the app version. The '%@' placeholder is the version number. So it will look like 'Version 2'. */
+/*[UNTRANSLATED] Text showing the app version. The '%@' placeholder is the version number. So it will look like 'Version 2'. */
 "APP_VERSION" = "Version %@";
 
 /* Text above change region button that allows user to select their desired server region */
@@ -18,7 +18,7 @@
    Title of the button that dismisses the settings menu (InAppSettingsKit) */
 "DONE_ACTION" = "ပြီးပါပြီ";
 
-/* Text displayed while app loads */
+/*[UNTRANSLATED] Text displayed while app loads */
 "LOADING" = "Loading...";
 
 /* Log view title bar text */
@@ -30,23 +30,23 @@
 /* Description for the 'Mail not configured' message. (InAppSettingsKit) */
 "MAIL_NOT_CONFIGURED_DESC" = "အီးမေးလ်ပို့ရန်အတွက် ဤစက်ကို ပြင်ဆင်ထားခြင်းမရှိပါ။ ကျေးဇူးပြု၍ အပြင်အဆင်တွင်းတွင်ရှိသော မေးလ်အပြင်အဆင်တွင် ကျေးဇူးပြု၍ ဝင်ရောက်ပြင်ဆင်ပါ။";
 
-/* Alert title informing user there is no internet connection */
+/*[UNTRANSLATED] Alert title informing user there is no internet connection */
 "NO_INTERNET" = "No Internet Connection";
 
 /* Alert OK Button
    Alert OK Button. (InAppSettingsKit) */
 "OK_BUTTON" = "အိုခေ";
 
-/* Alert message informing the user they should open the app to finish connecting to the VPN. */
+/*[UNTRANSLATED] Alert message informing the user they should open the app to finish connecting to the VPN. */
 "OPEN_PSIPHON_APP" = "Please open Psiphon app to finish connecting.";
 
 /* Title of the settings (aka preferences) view (InAppSettingsKit) */
 "SETTINGS_TITLE" = "အပြင်အဆင်များ";
 
-/* Alert message informing user to turn on their cellular data or wifi to connect to the internet */
+/*[UNTRANSLATED] Alert message informing user to turn on their cellular data or wifi to connect to the internet */
 "TURN_ON_DATE" = "Turn on cellular data or use Wi-Fi to access data.";
 
-/* Alert message informing user they have to open the app */
+/*[UNTRANSLATED] Alert message informing user they have to open the app */
 "USE_PSIPHON_APP" = "To connect, use the Psiphon app";
 
 /* Status when the VPN is connected to a Psiphon server */
@@ -64,9 +64,9 @@
 /* Status when the VPN is in an invalid state. For example, if the user doesn't give permission for the VPN configuration to be installed, and therefore the Psiphon VPN can't even try to connect. */
 "VPN_STATUS_INVALID" = "ချိတ်ဆက်မှု ပြတ်တောက်သွားသည်";
 
-/* Status when the VPN was connected to a Psiphon server, got disconnected unexpectedly, and is currently trying to reconnect */
+/*[UNTRANSLATED] Status when the VPN was connected to a Psiphon server, got disconnected unexpectedly, and is currently trying to reconnect */
 "VPN_STATUS_RECONNECTING" = "Reconnecting";
 
-/* Status when the VPN is restarting. */
+/*[UNTRANSLATED] Status when the VPN is restarting. */
 "VPN_STATUS_RESTARTING" = "Restarting";
 

--- a/Shared/Strings/nb.lproj/Localizable.strings
+++ b/Shared/Strings/nb.lproj/Localizable.strings
@@ -4,7 +4,7 @@
 /* Text for app subtitle on main view. */
 "APP_SUB_TITLE_MAIN_VIEW" = "FORBI GRENSER";
 
-/* Text for app title on main view. */
+/*[UNTRANSLATED] Text for app title on main view. */
 "APP_TITLE_MAIN_VIEW" = "PSIPHON";
 
 /* Text showing the app version. The '%@' placeholder is the version number. So it will look like 'Version 2'. */
@@ -33,7 +33,7 @@
 /* Alert title informing user there is no internet connection */
 "NO_INTERNET" = "Ingen internettilknytning";
 
-/* Alert OK Button
+/*[UNTRANSLATED] Alert OK Button
    Alert OK Button. (InAppSettingsKit) */
 "OK_BUTTON" = "OK";
 

--- a/Shared/Strings/nl.lproj/Localizable.strings
+++ b/Shared/Strings/nl.lproj/Localizable.strings
@@ -1,13 +1,13 @@
-/* Text for button that tell users there will by a short video ad. */
+/*[UNTRANSLATED] Text for button that tell users there will by a short video ad. */
 "AD_LOADED" = "Watch a short video while we get ready to connect you";
 
-/* Text for app subtitle on main view. */
+/*[UNTRANSLATED] Text for app subtitle on main view. */
 "APP_SUB_TITLE_MAIN_VIEW" = "BEYOND BORDERS";
 
 /* Text for app title on main view. */
 "APP_TITLE_MAIN_VIEW" = "PSIPHON ";
 
-/* Text showing the app version. The '%@' placeholder is the version number. So it will look like 'Version 2'. */
+/*[UNTRANSLATED] Text showing the app version. The '%@' placeholder is the version number. So it will look like 'Version 2'. */
 "APP_VERSION" = "Version %@";
 
 /* Text above change region button that allows user to select their desired server region */
@@ -30,20 +30,20 @@
 /* Description for the 'Mail not configured' message. (InAppSettingsKit) */
 "MAIL_NOT_CONFIGURED_DESC" = "Dit apparaat is niet geconfigureerd voor het verzenden van e-mail. Configureer aub eerst de Mail-instellingen in de Instellingen-app.";
 
-/* Alert title informing user there is no internet connection */
+/*[UNTRANSLATED] Alert title informing user there is no internet connection */
 "NO_INTERNET" = "No Internet Connection";
 
-/* Alert OK Button
+/*[UNTRANSLATED] Alert OK Button
    Alert OK Button. (InAppSettingsKit) */
 "OK_BUTTON" = "OK";
 
-/* Alert message informing the user they should open the app to finish connecting to the VPN. */
+/*[UNTRANSLATED] Alert message informing the user they should open the app to finish connecting to the VPN. */
 "OPEN_PSIPHON_APP" = "Please open Psiphon app to finish connecting.";
 
-/* Title of the settings (aka preferences) view (InAppSettingsKit) */
+/*[UNTRANSLATED] Title of the settings (aka preferences) view (InAppSettingsKit) */
 "SETTINGS_TITLE" = "Settings";
 
-/* Alert message informing user to turn on their cellular data or wifi to connect to the internet */
+/*[UNTRANSLATED] Alert message informing user to turn on their cellular data or wifi to connect to the internet */
 "TURN_ON_DATE" = "Turn on cellular data or use Wi-Fi to access data.";
 
 /* Alert message informing user they have to open the app */
@@ -64,7 +64,7 @@
 /* Status when the VPN is in an invalid state. For example, if the user doesn't give permission for the VPN configuration to be installed, and therefore the Psiphon VPN can't even try to connect. */
 "VPN_STATUS_INVALID" = "Verbroken";
 
-/* Status when the VPN was connected to a Psiphon server, got disconnected unexpectedly, and is currently trying to reconnect */
+/*[UNTRANSLATED] Status when the VPN was connected to a Psiphon server, got disconnected unexpectedly, and is currently trying to reconnect */
 "VPN_STATUS_RECONNECTING" = "Reconnecting";
 
 /* Status when the VPN is restarting. */

--- a/Shared/Strings/pt-BR.lproj/Localizable.strings
+++ b/Shared/Strings/pt-BR.lproj/Localizable.strings
@@ -1,16 +1,16 @@
-/* Text for button that tell users there will by a short video ad. */
+/*[UNTRANSLATED] Text for button that tell users there will by a short video ad. */
 "AD_LOADED" = "Watch a short video while we get ready to connect you";
 
-/* Text for app subtitle on main view. */
+/*[UNTRANSLATED] Text for app subtitle on main view. */
 "APP_SUB_TITLE_MAIN_VIEW" = "BEYOND BORDERS";
 
-/* Text for app title on main view. */
+/*[UNTRANSLATED] Text for app title on main view. */
 "APP_TITLE_MAIN_VIEW" = "PSIPHON";
 
-/* Text showing the app version. The '%@' placeholder is the version number. So it will look like 'Version 2'. */
+/*[UNTRANSLATED] Text showing the app version. The '%@' placeholder is the version number. So it will look like 'Version 2'. */
 "APP_VERSION" = "Version %@";
 
-/* Text above change region button that allows user to select their desired server region */
+/*[UNTRANSLATED] Text above change region button that allows user to select their desired server region */
 "CHANGE_REGION" = "Change Region";
 
 /* Done button in navigation bar
@@ -21,29 +21,29 @@
 /* Text displayed while app loads */
 "LOADING" = "Carregando";
 
-/* Log view title bar text */
+/*[UNTRANSLATED] Log view title bar text */
 "LOGS_TITLE" = "Logs";
 
-/* Shown when the device is not configured for sending email. (InAppSettingsKit) */
+/*[UNTRANSLATED] Shown when the device is not configured for sending email. (InAppSettingsKit) */
 "MAIL_NOT_CONFIGURED" = "Mail not configured";
 
-/* Description for the 'Mail not configured' message. (InAppSettingsKit) */
+/*[UNTRANSLATED] Description for the 'Mail not configured' message. (InAppSettingsKit) */
 "MAIL_NOT_CONFIGURED_DESC" = "This device is not configured for sending Email. Please configure the Mail settings in the Settings app.";
 
-/* Alert title informing user there is no internet connection */
+/*[UNTRANSLATED] Alert title informing user there is no internet connection */
 "NO_INTERNET" = "No Internet Connection";
 
-/* Alert OK Button
+/*[UNTRANSLATED] Alert OK Button
    Alert OK Button. (InAppSettingsKit) */
 "OK_BUTTON" = "OK";
 
-/* Alert message informing the user they should open the app to finish connecting to the VPN. */
+/*[UNTRANSLATED] Alert message informing the user they should open the app to finish connecting to the VPN. */
 "OPEN_PSIPHON_APP" = "Please open Psiphon app to finish connecting.";
 
 /* Title of the settings (aka preferences) view (InAppSettingsKit) */
 "SETTINGS_TITLE" = "Configurações";
 
-/* Alert message informing user to turn on their cellular data or wifi to connect to the internet */
+/*[UNTRANSLATED] Alert message informing user to turn on their cellular data or wifi to connect to the internet */
 "TURN_ON_DATE" = "Turn on cellular data or use Wi-Fi to access data.";
 
 /* Alert message informing user they have to open the app */
@@ -64,7 +64,7 @@
 /* Status when the VPN is in an invalid state. For example, if the user doesn't give permission for the VPN configuration to be installed, and therefore the Psiphon VPN can't even try to connect. */
 "VPN_STATUS_INVALID" = "Desconectado";
 
-/* Status when the VPN was connected to a Psiphon server, got disconnected unexpectedly, and is currently trying to reconnect */
+/*[UNTRANSLATED] Status when the VPN was connected to a Psiphon server, got disconnected unexpectedly, and is currently trying to reconnect */
 "VPN_STATUS_RECONNECTING" = "Reconnecting";
 
 /* Status when the VPN is restarting. */

--- a/Shared/Strings/pt-PT.lproj/Localizable.strings
+++ b/Shared/Strings/pt-PT.lproj/Localizable.strings
@@ -1,13 +1,13 @@
-/* Text for button that tell users there will by a short video ad. */
+/*[UNTRANSLATED] Text for button that tell users there will by a short video ad. */
 "AD_LOADED" = "Watch a short video while we get ready to connect you";
 
-/* Text for app subtitle on main view. */
+/*[UNTRANSLATED] Text for app subtitle on main view. */
 "APP_SUB_TITLE_MAIN_VIEW" = "BEYOND BORDERS";
 
-/* Text for app title on main view. */
+/*[UNTRANSLATED] Text for app title on main view. */
 "APP_TITLE_MAIN_VIEW" = "PSIPHON";
 
-/* Text showing the app version. The '%@' placeholder is the version number. So it will look like 'Version 2'. */
+/*[UNTRANSLATED] Text showing the app version. The '%@' placeholder is the version number. So it will look like 'Version 2'. */
 "APP_VERSION" = "Version %@";
 
 /* Text above change region button that allows user to select their desired server region */
@@ -27,23 +27,23 @@
 /* Shown when the device is not configured for sending email. (InAppSettingsKit) */
 "MAIL_NOT_CONFIGURED" = "Correio não configurado";
 
-/* Description for the 'Mail not configured' message. (InAppSettingsKit) */
+/*[UNTRANSLATED] Description for the 'Mail not configured' message. (InAppSettingsKit) */
 "MAIL_NOT_CONFIGURED_DESC" = "This device is not configured for sending Email. Please configure the Mail settings in the Settings app.";
 
-/* Alert title informing user there is no internet connection */
+/*[UNTRANSLATED] Alert title informing user there is no internet connection */
 "NO_INTERNET" = "No Internet Connection";
 
 /* Alert OK Button
    Alert OK Button. (InAppSettingsKit) */
 "OK_BUTTON" = "ACEITAR";
 
-/* Alert message informing the user they should open the app to finish connecting to the VPN. */
+/*[UNTRANSLATED] Alert message informing the user they should open the app to finish connecting to the VPN. */
 "OPEN_PSIPHON_APP" = "Please open Psiphon app to finish connecting.";
 
 /* Title of the settings (aka preferences) view (InAppSettingsKit) */
 "SETTINGS_TITLE" = "Definições";
 
-/* Alert message informing user to turn on their cellular data or wifi to connect to the internet */
+/*[UNTRANSLATED] Alert message informing user to turn on their cellular data or wifi to connect to the internet */
 "TURN_ON_DATE" = "Turn on cellular data or use Wi-Fi to access data.";
 
 /* Alert message informing user they have to open the app */
@@ -67,6 +67,6 @@
 /* Status when the VPN was connected to a Psiphon server, got disconnected unexpectedly, and is currently trying to reconnect */
 "VPN_STATUS_RECONNECTING" = "A Reconetar";
 
-/* Status when the VPN is restarting. */
+/*[UNTRANSLATED] Status when the VPN is restarting. */
 "VPN_STATUS_RESTARTING" = "Restarting";
 

--- a/Shared/Strings/ru.lproj/Localizable.strings
+++ b/Shared/Strings/ru.lproj/Localizable.strings
@@ -4,7 +4,7 @@
 /* Text for app subtitle on main view. */
 "APP_SUB_TITLE_MAIN_VIEW" = "ЗА ПРЕДЕЛОМ ОГРАНИЧЕНИЙ";
 
-/* Text for app title on main view. */
+/*[UNTRANSLATED] Text for app title on main view. */
 "APP_TITLE_MAIN_VIEW" = "PSIPHON";
 
 /* Text showing the app version. The '%@' placeholder is the version number. So it will look like 'Version 2'. */
@@ -33,7 +33,7 @@
 /* Alert title informing user there is no internet connection */
 "NO_INTERNET" = "Отсутствует подключение к интернету";
 
-/* Alert OK Button
+/*[UNTRANSLATED] Alert OK Button
    Alert OK Button. (InAppSettingsKit) */
 "OK_BUTTON" = "OK";
 

--- a/Shared/Strings/th.lproj/Localizable.strings
+++ b/Shared/Strings/th.lproj/Localizable.strings
@@ -1,16 +1,16 @@
-/* Text for button that tell users there will by a short video ad. */
+/*[UNTRANSLATED] Text for button that tell users there will by a short video ad. */
 "AD_LOADED" = "Watch a short video while we get ready to connect you";
 
-/* Text for app subtitle on main view. */
+/*[UNTRANSLATED] Text for app subtitle on main view. */
 "APP_SUB_TITLE_MAIN_VIEW" = "BEYOND BORDERS";
 
-/* Text for app title on main view. */
+/*[UNTRANSLATED] Text for app title on main view. */
 "APP_TITLE_MAIN_VIEW" = "PSIPHON";
 
-/* Text showing the app version. The '%@' placeholder is the version number. So it will look like 'Version 2'. */
+/*[UNTRANSLATED] Text showing the app version. The '%@' placeholder is the version number. So it will look like 'Version 2'. */
 "APP_VERSION" = "Version %@";
 
-/* Text above change region button that allows user to select their desired server region */
+/*[UNTRANSLATED] Text above change region button that allows user to select their desired server region */
 "CHANGE_REGION" = "Change Region";
 
 /* Done button in navigation bar
@@ -18,55 +18,55 @@
    Title of the button that dismisses the settings menu (InAppSettingsKit) */
 "DONE_ACTION" = "เสร็จสิ้น";
 
-/* Text displayed while app loads */
+/*[UNTRANSLATED] Text displayed while app loads */
 "LOADING" = "Loading...";
 
-/* Log view title bar text */
+/*[UNTRANSLATED] Log view title bar text */
 "LOGS_TITLE" = "Logs";
 
-/* Shown when the device is not configured for sending email. (InAppSettingsKit) */
+/*[UNTRANSLATED] Shown when the device is not configured for sending email. (InAppSettingsKit) */
 "MAIL_NOT_CONFIGURED" = "Mail not configured";
 
-/* Description for the 'Mail not configured' message. (InAppSettingsKit) */
+/*[UNTRANSLATED] Description for the 'Mail not configured' message. (InAppSettingsKit) */
 "MAIL_NOT_CONFIGURED_DESC" = "This device is not configured for sending Email. Please configure the Mail settings in the Settings app.";
 
-/* Alert title informing user there is no internet connection */
+/*[UNTRANSLATED] Alert title informing user there is no internet connection */
 "NO_INTERNET" = "No Internet Connection";
 
 /* Alert OK Button
    Alert OK Button. (InAppSettingsKit) */
 "OK_BUTTON" = "ตกลง";
 
-/* Alert message informing the user they should open the app to finish connecting to the VPN. */
+/*[UNTRANSLATED] Alert message informing the user they should open the app to finish connecting to the VPN. */
 "OPEN_PSIPHON_APP" = "Please open Psiphon app to finish connecting.";
 
 /* Title of the settings (aka preferences) view (InAppSettingsKit) */
 "SETTINGS_TITLE" = "ตั้งค่า";
 
-/* Alert message informing user to turn on their cellular data or wifi to connect to the internet */
+/*[UNTRANSLATED] Alert message informing user to turn on their cellular data or wifi to connect to the internet */
 "TURN_ON_DATE" = "Turn on cellular data or use Wi-Fi to access data.";
 
 /* Alert message informing user they have to open the app */
 "USE_PSIPHON_APP" = "To connect, use the Psiphon application.";
 
-/* Status when the VPN is connected to a Psiphon server */
+/*[UNTRANSLATED] Status when the VPN is connected to a Psiphon server */
 "VPN_STATUS_CONNECTED" = "Connected";
 
 /* Status when the VPN is connecting; that is, trying to connect to a Psiphon server */
 "VPN_STATUS_CONNECTING" = "กำลังติดต่อ";
 
-/* Status when the VPN is not connected to a Psiphon server, not trying to connect, and not in an error state */
+/*[UNTRANSLATED] Status when the VPN is not connected to a Psiphon server, not trying to connect, and not in an error state */
 "VPN_STATUS_DISCONNECTED" = "Disconnected";
 
-/* Status when the VPN is disconnecting. Sometimes going from connected to disconnected can take some time, and this is that state. */
+/*[UNTRANSLATED] Status when the VPN is disconnecting. Sometimes going from connected to disconnected can take some time, and this is that state. */
 "VPN_STATUS_DISCONNECTING" = "Disconnecting";
 
 /* Status when the VPN is in an invalid state. For example, if the user doesn't give permission for the VPN configuration to be installed, and therefore the Psiphon VPN can't even try to connect. */
 "VPN_STATUS_INVALID" = "Invalid";
 
-/* Status when the VPN was connected to a Psiphon server, got disconnected unexpectedly, and is currently trying to reconnect */
+/*[UNTRANSLATED] Status when the VPN was connected to a Psiphon server, got disconnected unexpectedly, and is currently trying to reconnect */
 "VPN_STATUS_RECONNECTING" = "Reconnecting";
 
-/* Status when the VPN is restarting. */
+/*[UNTRANSLATED] Status when the VPN is restarting. */
 "VPN_STATUS_RESTARTING" = "Restarting";
 

--- a/Shared/Strings/tk.lproj/Localizable.strings
+++ b/Shared/Strings/tk.lproj/Localizable.strings
@@ -1,13 +1,13 @@
-/* Text for button that tell users there will by a short video ad. */
+/*[UNTRANSLATED] Text for button that tell users there will by a short video ad. */
 "AD_LOADED" = "Watch a short video while we get ready to connect you";
 
-/* Text for app subtitle on main view. */
+/*[UNTRANSLATED] Text for app subtitle on main view. */
 "APP_SUB_TITLE_MAIN_VIEW" = "BEYOND BORDERS";
 
-/* Text for app title on main view. */
+/*[UNTRANSLATED] Text for app title on main view. */
 "APP_TITLE_MAIN_VIEW" = "PSIPHON";
 
-/* Text showing the app version. The '%@' placeholder is the version number. So it will look like 'Version 2'. */
+/*[UNTRANSLATED] Text showing the app version. The '%@' placeholder is the version number. So it will look like 'Version 2'. */
 "APP_VERSION" = "Version %@";
 
 /* Text above change region button that allows user to select their desired server region */
@@ -18,7 +18,7 @@
    Title of the button that dismisses the settings menu (InAppSettingsKit) */
 "DONE_ACTION" = "Boldy";
 
-/* Text displayed while app loads */
+/*[UNTRANSLATED] Text displayed while app loads */
 "LOADING" = "Loading...";
 
 /* Log view title bar text */
@@ -30,20 +30,20 @@
 /* Description for the 'Mail not configured' message. (InAppSettingsKit) */
 "MAIL_NOT_CONFIGURED_DESC" = "Bu enjam email ugratmaga ugurlaşmady. Hayyš, email sazlamalaryny Sazlama programmasynda tertibe sal.";
 
-/* Alert title informing user there is no internet connection */
+/*[UNTRANSLATED] Alert title informing user there is no internet connection */
 "NO_INTERNET" = "No Internet Connection";
 
 /* Alert OK Button
    Alert OK Button. (InAppSettingsKit) */
 "OK_BUTTON" = "Bolýar";
 
-/* Alert message informing the user they should open the app to finish connecting to the VPN. */
+/*[UNTRANSLATED] Alert message informing the user they should open the app to finish connecting to the VPN. */
 "OPEN_PSIPHON_APP" = "Please open Psiphon app to finish connecting.";
 
 /* Title of the settings (aka preferences) view (InAppSettingsKit) */
 "SETTINGS_TITLE" = "Sazlamalar";
 
-/* Alert message informing user to turn on their cellular data or wifi to connect to the internet */
+/*[UNTRANSLATED] Alert message informing user to turn on their cellular data or wifi to connect to the internet */
 "TURN_ON_DATE" = "Turn on cellular data or use Wi-Fi to access data.";
 
 /* Alert message informing user they have to open the app */
@@ -64,9 +64,9 @@
 /* Status when the VPN is in an invalid state. For example, if the user doesn't give permission for the VPN configuration to be installed, and therefore the Psiphon VPN can't even try to connect. */
 "VPN_STATUS_INVALID" = "Birikmedi";
 
-/* Status when the VPN was connected to a Psiphon server, got disconnected unexpectedly, and is currently trying to reconnect */
+/*[UNTRANSLATED] Status when the VPN was connected to a Psiphon server, got disconnected unexpectedly, and is currently trying to reconnect */
 "VPN_STATUS_RECONNECTING" = "Reconnecting";
 
-/* Status when the VPN is restarting. */
+/*[UNTRANSLATED] Status when the VPN is restarting. */
 "VPN_STATUS_RESTARTING" = "Restarting";
 

--- a/Shared/Strings/tr.lproj/Localizable.strings
+++ b/Shared/Strings/tr.lproj/Localizable.strings
@@ -1,16 +1,16 @@
-/* Text for button that tell users there will by a short video ad. */
+/*[UNTRANSLATED] Text for button that tell users there will by a short video ad. */
 "AD_LOADED" = "Watch a short video while we get ready to connect you";
 
-/* Text for app subtitle on main view. */
+/*[UNTRANSLATED] Text for app subtitle on main view. */
 "APP_SUB_TITLE_MAIN_VIEW" = "BEYOND BORDERS";
 
-/* Text for app title on main view. */
+/*[UNTRANSLATED] Text for app title on main view. */
 "APP_TITLE_MAIN_VIEW" = "PSIPHON";
 
-/* Text showing the app version. The '%@' placeholder is the version number. So it will look like 'Version 2'. */
+/*[UNTRANSLATED] Text showing the app version. The '%@' placeholder is the version number. So it will look like 'Version 2'. */
 "APP_VERSION" = "Version %@";
 
-/* Text above change region button that allows user to select their desired server region */
+/*[UNTRANSLATED] Text above change region button that allows user to select their desired server region */
 "CHANGE_REGION" = "Change Region";
 
 /* Done button in navigation bar
@@ -24,26 +24,26 @@
 /* Log view title bar text */
 "LOGS_TITLE" = "Günlükler";
 
-/* Shown when the device is not configured for sending email. (InAppSettingsKit) */
+/*[UNTRANSLATED] Shown when the device is not configured for sending email. (InAppSettingsKit) */
 "MAIL_NOT_CONFIGURED" = "Mail not configured";
 
-/* Description for the 'Mail not configured' message. (InAppSettingsKit) */
+/*[UNTRANSLATED] Description for the 'Mail not configured' message. (InAppSettingsKit) */
 "MAIL_NOT_CONFIGURED_DESC" = "This device is not configured for sending Email. Please configure the Mail settings in the Settings app.";
 
-/* Alert title informing user there is no internet connection */
+/*[UNTRANSLATED] Alert title informing user there is no internet connection */
 "NO_INTERNET" = "No Internet Connection";
 
 /* Alert OK Button
    Alert OK Button. (InAppSettingsKit) */
 "OK_BUTTON" = "Tamam";
 
-/* Alert message informing the user they should open the app to finish connecting to the VPN. */
+/*[UNTRANSLATED] Alert message informing the user they should open the app to finish connecting to the VPN. */
 "OPEN_PSIPHON_APP" = "Please open Psiphon app to finish connecting.";
 
 /* Title of the settings (aka preferences) view (InAppSettingsKit) */
 "SETTINGS_TITLE" = "Ayarlar";
 
-/* Alert message informing user to turn on their cellular data or wifi to connect to the internet */
+/*[UNTRANSLATED] Alert message informing user to turn on their cellular data or wifi to connect to the internet */
 "TURN_ON_DATE" = "Turn on cellular data or use Wi-Fi to access data.";
 
 /* Alert message informing user they have to open the app */
@@ -67,6 +67,6 @@
 /* Status when the VPN was connected to a Psiphon server, got disconnected unexpectedly, and is currently trying to reconnect */
 "VPN_STATUS_RECONNECTING" = "Yeniden bağlanıyor";
 
-/* Status when the VPN is restarting. */
+/*[UNTRANSLATED] Status when the VPN is restarting. */
 "VPN_STATUS_RESTARTING" = "Restarting";
 

--- a/Shared/Strings/uk.lproj/Localizable.strings
+++ b/Shared/Strings/uk.lproj/Localizable.strings
@@ -4,7 +4,7 @@
 /* Text for app subtitle on main view. */
 "APP_SUB_TITLE_MAIN_VIEW" = "БЕЗ КОРДОНІВ";
 
-/* Text for app title on main view. */
+/*[UNTRANSLATED] Text for app title on main view. */
 "APP_TITLE_MAIN_VIEW" = "PSIPHON";
 
 /* Text showing the app version. The '%@' placeholder is the version number. So it will look like 'Version 2'. */

--- a/Shared/Strings/uz.lproj/Localizable.strings
+++ b/Shared/Strings/uz.lproj/Localizable.strings
@@ -4,7 +4,7 @@
 /* Text for app subtitle on main view. */
 "APP_SUB_TITLE_MAIN_VIEW" = "CHEKLANMAGAN";
 
-/* Text for app title on main view. */
+/*[UNTRANSLATED] Text for app title on main view. */
 "APP_TITLE_MAIN_VIEW" = "PSIPHON";
 
 /* Text showing the app version. The '%@' placeholder is the version number. So it will look like 'Version 2'. */
@@ -33,7 +33,7 @@
 /* Alert title informing user there is no internet connection */
 "NO_INTERNET" = "Internet bilan aloqa yo‘q";
 
-/* Alert OK Button
+/*[UNTRANSLATED] Alert OK Button
    Alert OK Button. (InAppSettingsKit) */
 "OK_BUTTON" = "OK";
 

--- a/Shared/Strings/vi.lproj/Localizable.strings
+++ b/Shared/Strings/vi.lproj/Localizable.strings
@@ -4,7 +4,7 @@
 /* Text for app subtitle on main view. */
 "APP_SUB_TITLE_MAIN_VIEW" = "BÊN KIA BIẾN GIỚI";
 
-/* Text for app title on main view. */
+/*[UNTRANSLATED] Text for app title on main view. */
 "APP_TITLE_MAIN_VIEW" = "PSIPHON";
 
 /* Text showing the app version. The '%@' placeholder is the version number. So it will look like 'Version 2'. */
@@ -33,7 +33,7 @@
 /* Alert title informing user there is no internet connection */
 "NO_INTERNET" = "Không Có Kết Nối Internet";
 
-/* Alert OK Button
+/*[UNTRANSLATED] Alert OK Button
    Alert OK Button. (InAppSettingsKit) */
 "OK_BUTTON" = "OK";
 

--- a/Shared/Strings/zh-Hant.lproj/Localizable.strings
+++ b/Shared/Strings/zh-Hant.lproj/Localizable.strings
@@ -33,7 +33,7 @@
 /* Alert title informing user there is no internet connection */
 "NO_INTERNET" = "無網路連線　";
 
-/* Alert OK Button
+/*[UNTRANSLATED] Alert OK Button
    Alert OK Button. (InAppSettingsKit) */
 "OK_BUTTON" = "OK";
 


### PR DESCRIPTION
Now untranslated strings are marked as such, so they won't be used for fallbacks.