### PR TITLE
Fix: PulsingHaloLayer disappearing and not staying centered to start/stop button

### DIFF
--- a/Psiphon/MainViewController.m
+++ b/Psiphon/MainViewController.m
@@ -191,6 +191,11 @@ static BOOL (^safeStringsEqual)(NSString *, NSString *) = ^BOOL(NSString *a, NSS
 - (void)viewDidLayoutSubviews {
     [super viewDidLayoutSubviews];
     backgroundGradient.frame = self.view.bounds;
+
+    if (isStartStopButtonHaloOn && startStopButtonHalo != nil) {
+        // Keep pulsing halo centered on the start/stop button
+        startStopButtonHalo.position = startStopButton.center;
+    }
 }
 
 - (void)viewWillAppear:(BOOL)animated {
@@ -215,6 +220,13 @@ static BOOL (^safeStringsEqual)(NSString *, NSString *) = ^BOOL(NSString *a, NSS
 - (void)viewDidDisappear:(BOOL)animated {
     LOG_DEBUG();
     [super viewDidDisappear:animated];
+
+    if (isStartStopButtonHaloOn && startStopButtonHalo != nil) {
+        // The pulsing halo animation will complete when MainViewController's view disappears.
+        // Subsequently, PulsingHaloLayer will remove itself from its superview (see PulsingHaloLayer.m).
+        // PulsingHaloLayer will be re-added if needed when MainViewController's view re-appears.
+        [self removePulsingHaloLayer];
+    }
 }
 
 - (UIStatusBarStyle)preferredStatusBarStyle {
@@ -390,7 +402,6 @@ static BOOL (^safeStringsEqual)(NSString *, NSString *) = ^BOOL(NSString *a, NSS
 
 - (void)removePulsingHaloLayer {
     [startStopButtonHalo stop];
-
     isStartStopButtonHaloOn = FALSE;
 }
 


### PR DESCRIPTION
- PulsingHaloLayer was only centered to the start/stop button upon creation, but `PulsingHaloLayer.center` needs to be updated in each call to `viewDidLayoutSubviews` in case the start/stop button's position changed.
- PulsingHaloLayer will remove itself from its superview when its animation completes (https://github.com/shu223/PulsingHalo/blob/0.2.8/PulsingHalo/PulsingHaloLayer.m#L194-L200). Its animation will complete when its parent view is no longer visible. The solution is to remove PulsingHaloLayer on `viewDidDisappear` in `MainViewController` and re-add it if necessary when MainViewController reappears (`viewDidAppear`).