### PR TITLE
Fix VPNManager race condition

### DIFF
--- a/Psiphon/AdManager.m
+++ b/Psiphon/AdManager.m
@@ -44,8 +44,7 @@
         vpnManager = [VPNManager sharedInstance];
 
         [[NSNotificationCenter defaultCenter]
-          addObserver:self selector:@selector(vpnStatusDidChange) name:@kVPNStatusChangeNotificationName object:vpnManager];
-        //TODO: stop listening on dealloc.
+          addObserver:self selector:@selector(vpnStatusDidChange) name:kVPNStatusChangeNotificationName object:vpnManager];
     }
     return self;
 }
@@ -123,7 +122,7 @@
         [self.untunneledInterstitial showFromViewController:[[AppDelegate sharedAppDelegate] getAdsPresentingViewController]];
     } else {
         // Start the tunnel
-        [vpnManager startTunnelWithCompletionHandler:^(NSError *error) {}];
+        [vpnManager startTunnel];
     }
 }
 
@@ -179,7 +178,7 @@
     [self postAdsLoadStateDidChangeNotification];
 
     // Start the tunnel
-    [vpnManager startTunnelWithCompletionHandler:^(NSError *error) {}];
+    [vpnManager startTunnel];
 }
 
 @end

--- a/Psiphon/AppDelegate.m
+++ b/Psiphon/AppDelegate.m
@@ -291,26 +291,17 @@
         if([iapHelper hasActiveSubscriptionForDate:[NSDate date]] && ![iapHelper verifyReceipt]) {
             // Stop the VPN and prompt user to refresh app receipt.
             [vpnManager stopVPN];
-            NSString *alertTitle = NSLocalizedStringWithDefaultValue(@"BAD_RECEIPT_ALERT_TITLE", nil, [NSBundle mainBundle], @"Invalid app receipt", @"Alert title informing user that app receipt is not valid");
 
-            NSString *alertMessage = NSLocalizedStringWithDefaultValue(@"BAD_RECEIPT_ALERT_MESSAGE", nil, [NSBundle mainBundle], @"Your subscription receipt cannot be verified, please refresh it and try again.", @"Alert message informing user that subscription receipt cannot be verified");
+            [UIAlertController presentSimpleAlertWithTitle:NSLocalizedStringWithDefaultValue(@"BAD_RECEIPT_ALERT_TITLE", nil, [NSBundle mainBundle], @"Invalid app receipt", @"Alert title informing user that app receipt is not valid")
+                                                   message:NSLocalizedStringWithDefaultValue(@"BAD_RECEIPT_ALERT_MESSAGE", nil, [NSBundle mainBundle], @"Your subscription receipt cannot be verified, please refresh it and try again.", @"Alert message informing user that subscription receipt cannot be verified")
+                                            preferredStyle:UIAlertControllerStyleAlert
+                                                 okHandler:^(UIAlertAction *action) {
+                                                     IAPViewController *iapViewController = [[IAPViewController alloc]init];
+                                                     iapViewController.openedFromSettings = NO;
+                                                     UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:iapViewController];
+                                                     [rootContainerController presentViewController:navController animated:YES completion:nil];
+                                                 }];
 
-            UIAlertController *alert = [UIAlertController
-                                        alertControllerWithTitle:alertTitle
-                                        message:alertMessage
-                                        preferredStyle:UIAlertControllerStyleAlert];
-
-            UIAlertAction *defaultAction = [UIAlertAction
-                                            actionWithTitle:NSLocalizedStringWithDefaultValue(@"OK_BUTTON", nil, [NSBundle mainBundle], @"OK", @"Alert OK Button")
-                                            style:UIAlertActionStyleDefault
-                                            handler:^(UIAlertAction *action) {
-                                                IAPViewController *iapViewController = [[IAPViewController alloc]init];
-                                                iapViewController.openedFromSettings = NO;
-                                                UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:iapViewController];
-                                                [rootContainerController presentViewController:navController animated:YES completion:nil];
-                                            }];
-            [alert addAction:defaultAction];
-            [alert presentFromTopController];
             return;
         }
 
@@ -338,23 +329,12 @@
                     // and terminate the app due to 'Invalid Receipt' when user clicks 'OK'.
                     [vpnManager stopVPN];
 
-                    NSString *alertTitle = NSLocalizedStringWithDefaultValue(@"BAD_CLOCK_ALERT_TITLE", nil, [NSBundle mainBundle], @"Clock is out of sync", @"Alert title informing user that the device clock needs to be updated with current time");
-
-                    NSString *alertMessage = NSLocalizedStringWithDefaultValue(@"BAD_CLOCK_ALERT_MESSAGE", nil, [NSBundle mainBundle], @"We've detected the time on your device is out of sync with your time zone. Please update your clock settings and restart the app", @"Alert message informing user that the device clock needs to be updated with current time");
-
-                    UIAlertController *alert = [UIAlertController
-                                                alertControllerWithTitle:alertTitle
-                                                message:alertMessage
-                                                preferredStyle:UIAlertControllerStyleAlert];
-
-                    UIAlertAction *defaultAction = [UIAlertAction
-                                                    actionWithTitle:NSLocalizedStringWithDefaultValue(@"OK_BUTTON", nil, [NSBundle mainBundle], @"OK", @"Alert OK Button")
-                                                    style:UIAlertActionStyleDefault
-                                                    handler:^(UIAlertAction *action) {
-                                                        [[IAPHelper sharedInstance] terminateForInvalidReceipt];
-                                                    }];
-                    [alert addAction:defaultAction];
-                    [alert presentFromTopController];
+                    [UIAlertController presentSimpleAlertWithTitle:NSLocalizedStringWithDefaultValue(@"BAD_CLOCK_ALERT_TITLE", nil, [NSBundle mainBundle], @"Clock is out of sync", @"Alert title informing user that the device clock needs to be updated with current time")
+                                                           message:NSLocalizedStringWithDefaultValue(@"BAD_CLOCK_ALERT_MESSAGE", nil, [NSBundle mainBundle], @"We've detected the time on your device is out of sync with your time zone. Please update your clock settings and restart the app", @"Alert message informing user that the device clock needs to be updated with current time")
+                                                    preferredStyle:UIAlertControllerStyleAlert
+                                                         okHandler:^(UIAlertAction *action) {
+                                                             [[IAPHelper sharedInstance] terminateForInvalidReceipt];
+                                                         }];
                     return;
                 }
             }

--- a/Psiphon/AppDelegate.m
+++ b/Psiphon/AppDelegate.m
@@ -140,7 +140,7 @@
 
     // Listen for VPN status changes from VPNManager.
     [[NSNotificationCenter defaultCenter]
-      addObserver:self selector:@selector(onVPNStatusDidChange) name:@kVPNStatusChangeNotificationName object:vpnManager];
+      addObserver:self selector:@selector(onVPNStatusDidChange) name:kVPNStatusChangeNotificationName object:vpnManager];
 
     // Listen for the network extension messages.
     [self listenForNEMessages];

--- a/Psiphon/MainViewController.m
+++ b/Psiphon/MainViewController.m
@@ -152,17 +152,24 @@ static BOOL (^safeStringsEqual)(NSString *, NSString *) = ^BOOL(NSString *a, NSS
         //appSubTitleLabel.hidden = YES;
     }
 
-    [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(onVPNStatusDidChange)
-                                                 name:@kVPNStatusChangeNotificationName
-                                               object:vpnManager];
-
+    // Observer AdManager notifications
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(onAdStatusDidChange)
                                                  name:@kAdsDidLoad
                                                object:adManager];
+    // Observe VPNManager notifications
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(onVPNStatusDidChange)
+                                                 name:kVPNStatusChangeNotificationName
+                                               object:vpnManager];
 
-    // Observe IAP transaction notification
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(onVPNStartFailed)
+                                                 name:kVPNStartFailure
+                                               object:vpnManager];
+
+
+    // Observe IAP transaction notifications
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(updatedIAPTransactionState)
                                                  name:kIAPSKPaymentTransactionStatePurchased
@@ -272,6 +279,14 @@ static BOOL (^safeStringsEqual)(NSString *, NSString *) = ^BOOL(NSString *a, NSS
 }
 
 #pragma mark - UI callbacks
+
+- (void)onVPNStartFailed {
+    // Alert the user that the VPN failed to start, and that they should try again.
+    [UIAlertController presentSimpleAlertWithTitle:NSLocalizedStringWithDefaultValue(@"VPN_START_FAIL_TITLE", nil, [NSBundle mainBundle], @"Unable to start", @"Alert dialog title indicating to the user that Psiphon was unable to start (MainViewController)")
+                                           message:NSLocalizedStringWithDefaultValue(@"VPN_START_FAIL_MESSAGE", nil, [NSBundle mainBundle], @"An error occurred while starting Psiphon. Please try again. If this problem persists, try reinstalling the Psiphon app.", @"Alert dialog message informing the user that an error occurred while starting Psiphon (Do not translate 'Psiphon'). The user should try again, and if the problem persists, they should try reinstalling the app.")
+                                    preferredStyle:UIAlertControllerStyleAlert
+                                         okHandler:nil];
+}
 
 - (void)onVPNStatusDidChange {
     // Update UI

--- a/Psiphon/MainViewController.m
+++ b/Psiphon/MainViewController.m
@@ -364,18 +364,10 @@ static BOOL (^safeStringsEqual)(NSString *, NSString *) = ^BOOL(NSString *a, NSS
 }
 
 - (void)displayCorruptSettingsFileAlert {
-    UIAlertController *alert = [UIAlertController
-      alertControllerWithTitle:NSLocalizedStringWithDefaultValue(@"CORRUPT_SETTINGS_ALERT_TITLE", nil, [NSBundle mainBundle], @"Corrupt Settings", @"Alert dialog title (MainViewController)")
-                       message:NSLocalizedStringWithDefaultValue(@"CORRUPT_SETTINGS_MESSAGE", nil, [NSBundle mainBundle], @"Your app settings file appears to be corrupt. Try reinstalling the app to repair the file.", @"Alert dialog message informing the user that the settings file in the app is corrupt, and that they can potentially fix this issue by re-installing the app.")
-                preferredStyle:UIAlertControllerStyleAlert];
-
-    UIAlertAction *defaultAction = [UIAlertAction actionWithTitle:NSLocalizedStringWithDefaultValue(@"OK_BUTTON", nil, [NSBundle mainBundle], @"OK", @"Alert OK Button")
-                                                            style:UIAlertActionStyleDefault
-                                                          handler:^(UIAlertAction *action) {
-                                                              // Do nothing.
-                                                          }];
-    [alert addAction:defaultAction];
-    [alert presentFromTopController];
+    [UIAlertController presentSimpleAlertWithTitle:NSLocalizedStringWithDefaultValue(@"CORRUPT_SETTINGS_ALERT_TITLE", nil, [NSBundle mainBundle], @"Corrupt Settings", @"Alert dialog title (MainViewController)")
+                                           message:NSLocalizedStringWithDefaultValue(@"CORRUPT_SETTINGS_MESSAGE", nil, [NSBundle mainBundle], @"Your app settings file appears to be corrupt. Try reinstalling the app to repair the file.", @"Alert dialog message informing the user that the settings file in the app is corrupt, and that they can potentially fix this issue by re-installing the app.")
+                                    preferredStyle:UIAlertControllerStyleAlert
+                                         okHandler:nil];
 }
 
 - (NSString *)getVPNStatusDescription:(VPNStatus) status {

--- a/Psiphon/UIAlertController+Delegate.h
+++ b/Psiphon/UIAlertController+Delegate.h
@@ -21,6 +21,8 @@
 
 @interface UIAlertController (Delegate)
 
++ (void)presentSimpleAlertWithTitle:(NSString *_Nonnull)title message:(NSString *_Nonnull)message preferredStyle:(UIAlertControllerStyle)preferredStyle okHandler:(void (^ _Nullable)(UIAlertAction *_Nonnull action))okHandler;
+
 - (void)presentFromTopController;
 
 @end

--- a/Psiphon/UIAlertController+Delegate.m
+++ b/Psiphon/UIAlertController+Delegate.m
@@ -21,6 +21,13 @@
 
 @implementation UIAlertController (Delegate)
 
++ (void)presentSimpleAlertWithTitle:(NSString *_Nonnull)title message:(NSString *_Nonnull)message preferredStyle:(UIAlertControllerStyle)preferredStyle okHandler:(void (^ _Nullable)(UIAlertAction *action))okHandler {
+    UIAlertController *ac = [UIAlertController alertControllerWithTitle:title message:message preferredStyle:preferredStyle];
+    UIAlertAction *okAction = [UIAlertAction actionWithTitle:NSLocalizedStringWithDefaultValue(@"OK_BUTTON", nil, [NSBundle mainBundle], @"OK", @"Alert OK Button") style:UIAlertActionStyleDefault handler:okHandler];
+    [ac addAction:okAction];
+    [ac presentFromTopController];
+}
+
 + (UIViewController *)getTopMostViewController {
     UIViewController *topController = [UIApplication sharedApplication].keyWindow.rootViewController;
     while(topController.presentedViewController) {

--- a/Psiphon/VPNManager.h
+++ b/Psiphon/VPNManager.h
@@ -19,25 +19,40 @@
 
 #import <Foundation/Foundation.h>
 
-// NSNotification name for VPN status change notifications.
-#define kVPNStatusChangeNotificationName "VPNStatusChange"
+/**
+ * NSNotification name for VPN status change notifications.
+ * Notification with this name might be posted many times,
+ * without an actual change to the VPN status.
+ */
+#define kVPNStatusChangeNotificationName @"VPNStatusChange"
 
-static NSString *const VPNManagerErrorDomain = @"VPNManagerErrorDomain";
+/**
+ * NSNotification name for VPN start failures.
+ */
+#define kVPNStartFailure @"VPNStartFailure"
+
+
+static NSString *_Nonnull const VPNManagerErrorDomain = @"VPNManagerErrorDomain";
 
 /**
  * @typedef VPNManagerErrorCode
  * @abstract VPNManager error codes
  */
 typedef NS_ERROR_ENUM(VPNManagerErrorDomain, VPNManagerStartErrorCode) {
-    VPNManagerStartErrorLoadConfigsFailed = 1,
+    /*! @const VPNManagerStartErrorConfigLoadFailed Failed to load VPN configurations. */
+    VPNManagerStartErrorConfigLoadFailed = 1,
+    /*! @const VPNManagerStartErrorTooManyConfigsFounds More than expected VPN configurations found. */
     VPNManagerStartErrorTooManyConfigsFounds = 2,
-    VPNManagerStartErrorUserDeniedConfigInstall = 3,
+    /*! @const VPNManagerStartErrorConfigSaveFailed Failed to save VPN configuration. */
+    VPNManagerStartErrorConfigSaveFailed = 3,
+    /*! @const VPNManagerStartErrorNEStartFailed Failed to start VPN. */
     VPNManagerStartErrorNEStartFailed = 4,
 };
 
 #define VPNQueryErrorUserInfoQueryKey @"query"
 
-static NSString *const VPNQueryErrorDomain = @"VPNQueryErrorDomain";
+static NSString *_Nonnull const VPNQueryErrorDomain = @"VPNQueryErrorDomain";
+
 /**
  * @typedef VPNQueryErrorCode
  * @abstract VPN query error codes
@@ -73,21 +88,23 @@ typedef NS_ENUM(NSInteger, VPNStatus) {
 /**
  * @interface VPNManager
  * @discussion The VPNManager class is the single point of interaction with the Network Extension.
- *
+ * @attention VPNManager is not thread-safe.
  */
 @interface VPNManager : NSObject
 
+// TODO: remove UI flags and elements from VPNManager
 @property (nonatomic) BOOL startStopButtonPressed;
 
 + (instancetype _Nullable)sharedInstance;
 
 /**
- * Starts the network extension process and also the tunnel.
+ * Starts the Network Extension process and also the tunnel.
  * VPN will not start until startVPN is called.
- * @param completionHandler If no errors occurred, then error is set to nil.
- *        Error code is set to one of VPNManagerError* errors.
+ *
+ * @details To listen for errors starting Network Extension, interested
+ *          parties should observe kVPNStartFailure NSNotification.
  */
-- (void)startTunnelWithCompletionHandler:(nullable void (^)(NSError * _Nullable error))completionHandler;
+- (void)startTunnel;
 
 /**
  * Signals the network extension to start the VPN.

--- a/Psiphon/VPNManager.h
+++ b/Psiphon/VPNManager.h
@@ -22,27 +22,27 @@
 // NSNotification name for VPN status change notifications.
 #define kVPNStatusChangeNotificationName "VPNStatusChange"
 
-#define VPNManagerErrorDomain @"VPNManagerErrorDomain"
+static NSString *const VPNManagerErrorDomain = @"VPNManagerErrorDomain";
 
 /**
  * @typedef VPNManagerErrorCode
  * @abstract VPNManager error codes
  */
-typedef NS_ENUM(NSInteger, VPNManagerStartErrorCode) {
+typedef NS_ERROR_ENUM(VPNManagerErrorDomain, VPNManagerStartErrorCode) {
     VPNManagerStartErrorLoadConfigsFailed = 1,
     VPNManagerStartErrorTooManyConfigsFounds = 2,
     VPNManagerStartErrorUserDeniedConfigInstall = 3,
     VPNManagerStartErrorNEStartFailed = 4,
 };
 
-#define VPNQueryErrorDomain @"VPNQueryErrorDomain"
-#define VPNQueryKey @"query"
+#define VPNQueryErrorUserInfoQueryKey @"query"
 
+static NSString *const VPNQueryErrorDomain = @"VPNQueryErrorDomain";
 /**
  * @typedef VPNQueryErrorCode
  * @abstract VPN query error codes
  */
-typedef NS_ENUM(NSInteger, VPNQueryErrorCode) {
+typedef NS_ERROR_ENUM(VPNQueryErrorDomain, VPNQueryErrorCode) {
     VPNQueryErrorSendFailed = 1,
     VPNQueryErrorNilResponse = 2,
 };

--- a/Shared/PsiphonDataSharedDB.m
+++ b/Shared/PsiphonDataSharedDB.m
@@ -41,6 +41,8 @@
 @end
 
 @implementation PsiphonDataSharedDB {
+
+    // NSUserDefaults objects are thread-safe.
     NSUserDefaults *sharedDefaults;
 
     NSString *appGroupIdentifier;

--- a/Shared/Strings/en.lproj/Localizable.strings
+++ b/Shared/Strings/en.lproj/Localizable.strings
@@ -85,6 +85,12 @@
 /* Alert message informing user they have to open the app. DO NOT translate 'Psiphon'. */
 "USE_PSIPHON_APP" = "To connect, use the Psiphon app";
 
+/* Alert dialog message informing the user that an error occurred while starting Psiphon (Do not translate 'Psiphon'). The user should try again, and if the problem persists, they should try reinstalling the app. */
+"VPN_START_FAIL_MESSAGE" = "An error occurred while starting Psiphon. Please try again. If this problem persists, try reinstalling the Psiphon app.";
+
+/* Alert dialog title indicating to the user that Psiphon was unable to start (MainViewController) */
+"VPN_START_FAIL_TITLE" = "Unable to start";
+
 /* Status when the VPN is connected to a Psiphon server */
 "VPN_STATUS_CONNECTED" = "Connected";
 


### PR DESCRIPTION
Related issue: https://github.com/Psiphon-Inc/psiphon-issues/issues/393

## Changes:
- If a fatal error occurs, any installed VPN configuration will be removed:
  - If more than 1 configuration is found when loading configurations in `startTunnel`: https://github.com/Psiphon-Inc/psiphon-ios-vpn/pull/112/files#diff-b44a43bc4977cc55213109a539ac230cR201
  - If configuration save fails due to **only** `NEVPNErrorConfigurationInvalid` or `NEVPNErrorConfigurationUnknown` error codes: https://github.com/Psiphon-Inc/psiphon-ios-vpn/pull/112/files#diff-b44a43bc4977cc55213109a539ac230cR225

  All other [NEVPNError](https://developer.apple.com/documentation/networkextension/nevpnerror?language=objc) are considered fixable by retrying. In some cases, more granular error messages could be shown to the user.

- Users are alerted if an error occurs when starting the VPN. These errors were all silent previously.