### PR TITLE
Reset shownLandingPageForCurrentSession after buying Speed Boost

### DIFF
--- a/Psiphon/AppDelegate.h
+++ b/Psiphon/AppDelegate.h
@@ -47,6 +47,8 @@ typedef NS_ENUM(NSInteger, UserSubscriptionStatus) {
  */
 @property (nonatomic, readonly) RACReplaySubject<NSNumber *> *subscriptionStatus;
 
+@property (atomic) BOOL shownLandingPageForCurrentSession;
+
 + (AppDelegate *)sharedAppDelegate;
 + (BOOL)isFirstRunOfAppVersion;
 + (BOOL)isRunningUITest;

--- a/Psiphon/AppDelegate.m
+++ b/Psiphon/AppDelegate.m
@@ -87,7 +87,6 @@ PsiFeedbackLogType const LandingPageLogType = @"LandingPage";
 @property (nonatomic, readwrite) RACReplaySubject<NSNumber *> *adLoadingStatus;
 
 // Private properties
-@property (atomic) BOOL shownLandingPageForCurrentSession;
 @property (nonatomic) RACCompoundDisposable *compoundDisposable;
 
 @property (nonatomic) VPNManager *vpnManager;

--- a/Psiphon/PsiCash/ClientWrapper/PsiCashClient.m
+++ b/Psiphon/PsiCash/ClientWrapper/PsiCashClient.m
@@ -19,6 +19,7 @@
 
 #import <PsiCashLib/PsiCash.h>
 #import "PsiCashClient.h"
+#import "AppDelegate.h"
 #import "Asserts.h"
 #import "Authorization.h"
 #import "CustomIOSAlertView.h"
@@ -347,6 +348,8 @@ NSErrorDomain _Nonnull const PsiCashClientLibraryErrorDomain = @"PsiCashClientLi
             }
 
             [self updateContainerAuthTokens];
+            // Ensure homepage is shown when extension reconnects with new auth token
+            [AppDelegate sharedAppDelegate].shownLandingPageForCurrentSession = FALSE;
             [[Notifier sharedInstance] post:NotifierUpdatedAuthorizations completionHandler:^(BOOL success) {
                 // Do nothing.
             }];


### PR DESCRIPTION
- Ensures a homepage is opened on the next successful connect or reconnect