### PR TITLE
Add VPN start status check after starting the VPN (psicash)

### DIFF
--- a/Psiphon/VPNManager.h
+++ b/Psiphon/VPNManager.h
@@ -29,12 +29,8 @@ NS_ASSUME_NONNULL_BEGIN
 FOUNDATION_EXPORT NSErrorDomain const VPNManagerErrorDomain;
 
 typedef NS_ERROR_ENUM(VPNManagerErrorDomain, VPNManagerConfigErrorCode) {
-    /*! @const VPNManagerStartErrorConfigLoadFailed Failed to load VPN configurations. */
-    VPNManagerConfigErrorLoadFailed = 100,
-    /*! @const VPNManagerStartErrorTooManyConfigsFounds More than expected VPN configurations found. */
-    VPNManagerConfigErrorTooManyConfigsFounds = 101,
-    /*! @const VPNManagerStartErrorConfigSaveFailed Failed to save VPN configuration. */
-    VPNManagerConfigErrorConfigSaveFailed = 102,
+    /*! @const VPNManagerConfigMaybeCorrupt VPN configuration removed since it might have been corrupt. */
+      VPNManagerConfigRemovedMaybeCorrupt = 103,
 };
 
 typedef NS_ERROR_ENUM(VPNManagerErrorDomain, VPNManagerQueryErrorCode) {

--- a/Psiphon/VPNManager.m
+++ b/Psiphon/VPNManager.m
@@ -41,6 +41,12 @@
 #import "DispatchUtils.h"
 #import "RACTargetQueueScheduler.h"
 
+/**
+ * VPNStartSuccessCheckDelay is the delay interval for checking VPN status after starting it.
+ * We expect the VPN to be in a connecting/connected/reasserting state within this short time period after starting it.
+ */
+NSTimeInterval const VPNStartSuccessCheckDelay = 0.5;
+
 NSErrorDomain const VPNManagerErrorDomain = @"VPNManagerErrorDomain";
 
 PsiFeedbackLogType const VPNManagerLogType = @"VPNManager";
@@ -303,7 +309,7 @@ PsiFeedbackLogType const VPNManagerLogType = @"VPNManager";
 
     __weak VPNManager *weakSelf = self;
 
-    __block RACDisposable *disposable = [[[[[[[VPNManager loadTunnelProviderManager]
+    __block RACDisposable *disposable = [[[[[[[[[VPNManager loadTunnelProviderManager]
       map:^NETunnelProviderManager *(NETunnelProviderManager *providerManager) {
 
           if (!providerManager) {
@@ -333,7 +339,7 @@ PsiFeedbackLogType const VPNManagerLogType = @"VPNManager";
       flattenMap:^RACSignal *(NETunnelProviderManager *providerManager) {
           return [RACSignal defer:providerManager selectorWithErrorCallback:@selector(loadFromPreferencesWithCompletionHandler:)];
       }]
-      flattenMap:^RACSignal<NSNumber *> *(NETunnelProviderManager *providerManager) {
+      flattenMap:^RACSignal<NETunnelProviderManager *> *(NETunnelProviderManager *providerManager) {
 
           weakSelf.tunnelProviderManager = providerManager;
           NSError *error;
@@ -343,7 +349,40 @@ PsiFeedbackLogType const VPNManagerLogType = @"VPNManager";
           if (error) {
               return [RACSignal error:error];
           } else {
+              // The process of connecting to VPN started.
+              [weakSelf.internalStartStatus sendNext:@(VPNStartStatusFinished)];
+
+              return [RACSignal return:providerManager];
+          }
+
+      }]
+      delay:VPNStartSuccessCheckDelay]  // Delay before checking VPN status.
+      flattenMap:^RACSignal<RACUnit *> *(NETunnelProviderManager *providerManager) {
+
+          NEVPNStatus s = providerManager.connection.status;
+
+          // We expect the VPN to have started after the delay.
+
+          if (s == NEVPNStatusConnecting ||
+              s == NEVPNStatusConnected ||
+              s == NEVPNStatusReasserting) {
+
               return [RACSignal return:RACUnit.defaultUnit];
+
+          } else {
+
+              // The VPN is not in the expected connecting/connected state within VPNStartSuccessCheckDelay of starting.
+              // Due to the potential corruption of the VPN configuration, delete the VPN configuration.
+              //
+              // This bug has been observed in the system, and the only solution is to remove the VPN configuration.
+              //
+              return [[RACSignal defer:providerManager
+             selectorWithErrorCallback:@selector(removeFromPreferencesWithCompletionHandler:)]
+                flattenMap:^RACSignal *(id value) {
+                  // End the stream with an error.
+                    return [RACSignal error:[NSError errorWithDomain:VPNManagerErrorDomain code:VPNManagerConfigRemovedMaybeCorrupt]];
+                }];
+
           }
 
       }]
@@ -354,16 +393,17 @@ PsiFeedbackLogType const VPNManagerLogType = @"VPNManager";
           if ([error.domain isEqualToString:NEVPNErrorDomain] &&
                error.code == NEVPNErrorConfigurationReadWriteFailed &&
                [error.localizedDescription isEqualToString:@"permission denied"] ) {
-
+              // User denied permission.
               [weakSelf.internalStartStatus sendNext:@(VPNStartStatusFailedUserPermissionDenied)];
+
           } else {
+
               [weakSelf.internalStartStatus sendNext:@(VPNStartStatusFailedOther)];
           }
 
           [weakSelf.compoundDisposable removeDisposable:disposable];
-
-      } completed:^{
-          [weakSelf.internalStartStatus sendNext:@(VPNStartStatusFinished)];
+      }
+      completed:^{
           [weakSelf.compoundDisposable removeDisposable:disposable];
       }];
 


### PR DESCRIPTION
- If the VPN process is not in the expected state almost immediately
  after starting it, the VPN configuration is removed.

- This resolves the issue were the system is not able to start
  the VPN process due to reasons unknown yet, and uninstalling the app
  would not cause the VPN configuration to also be deleted.