### PR TITLE
Update disabling auto-start VPN on stop

### DIFF
--- a/Psiphon/AppDelegate.m
+++ b/Psiphon/AppDelegate.m
@@ -524,21 +524,6 @@ PsiFeedbackLogType const LandingPageLogType = @"LandingPage";
 
     [self.compoundDisposable addDisposable:vpnActiveDisposable];
 
-    // Checks if user previously preferred to have Connect On Demand enabled,
-    // Re-enable it upon subscription since it may have been disabled if the previous subscription expired.
-    // Disables Connect On Demand setting of the VPN Configuration.
-    BOOL userPreferredOnDemandSetting = [[NSUserDefaults standardUserDefaults]
-      boolForKey:SettingsConnectOnDemandBoolKey];
-
-    __block RACDisposable *onDemandDisposable = [[self.vpnManager setConnectOnDemandEnabled:userPreferredOnDemandSetting]
-      subscribeError:^(NSError *error) {
-          [weakSelf.compoundDisposable removeDisposable:onDemandDisposable];
-    } completed:^{
-          [weakSelf.compoundDisposable removeDisposable:onDemandDisposable];
-    }];
-
-    [self.compoundDisposable addDisposable:onDemandDisposable];
-
 }
 
 // Called on `IAPHelperUpdatedSubscriptionDictionaryNotification` notification.

--- a/Psiphon/MainViewController.m
+++ b/Psiphon/MainViewController.m
@@ -454,17 +454,18 @@ static BOOL (^safeStringsEqual)(NSString *, NSString *) = ^BOOL(NSString *a, NSS
                   // Alert the user that Connect On Demand is enabled, and if they
                   // would like Connect On Demand to be disabled, and the extension to be stopped.
                   NSString *alertTitle = NSLocalizedStringWithDefaultValue(@"CONNECT_ON_DEMAND_ALERT_TITLE", nil, [NSBundle mainBundle], @"Auto-start VPN is enabled", @"Alert dialog title informing user that 'Auto-start VPN' feature is enabled");
-                  NSString *alertMessage = NSLocalizedStringWithDefaultValue(@"CONNECT_ON_DEMAND_ALERT_BODY", nil, [NSBundle mainBundle], @"Cannot stop the VPN while \"Auto-start VPN\" is enabled.\nWould you like to disable \"Auto-start VPN\" on demand and stop the VPN?", "Alert dialog body informing the user that the 'Auto-start VPN on demand' feature is enabled and that the VPN cannot be stopped. Followed by asking the user if they would like to disable the 'Auto-start VPN on demand' feature, and stop the VPN.");
+                  NSString *alertMessage = NSLocalizedStringWithDefaultValue(@"CONNECT_ON_DEMAND_ALERT_BODY", nil, [NSBundle mainBundle], @"\"Auto-start VPN\" will be temporarily disabled until the next time Psiphon VPN is started.", "Alert dialog body informing the user that the 'Auto-start VPN on demand' feature will be disabled and that the VPN cannot be stopped.");
 
                   UIAlertController *alert = [UIAlertController
                                               alertControllerWithTitle:alertTitle message:alertMessage preferredStyle:UIAlertControllerStyleAlert];
 
-                  UIAlertAction *disableAction = [UIAlertAction
-                    actionWithTitle:NSLocalizedStringWithDefaultValue(@"DISABLE_BUTTON", nil, [NSBundle mainBundle], @"Disable Auto-start VPN and Stop", @"Disable Auto-start VPN feature and Stop the VPN button label")
-                    style:UIAlertActionStyleDestructive
+                  UIAlertAction *stopUntilNextStartAction = [UIAlertAction
+                    actionWithTitle:NSLocalizedStringWithDefaultValue(@"OK_BUTTON", nil, [NSBundle mainBundle], @"OK", @"OK button title")
+                    style:UIAlertActionStyleDefault
                     handler:^(UIAlertAction *action) {
+
                         // Disable "Connect On Demand" and stop the VPN.
-                        [[NSUserDefaults standardUserDefaults] setBool:FALSE forKey:SettingsConnectOnDemandBoolKey];
+                        [[NSUserDefaults standardUserDefaults] setBool:TRUE forKey:VPNManagerConnectOnDemandUntilNextStartBoolKey];
 
                         __block RACDisposable *disposable = [[weakSelf.vpnManager setConnectOnDemandEnabled:FALSE]
                           subscribeNext:^(NSNumber *x) {
@@ -479,17 +480,8 @@ static BOOL (^safeStringsEqual)(NSString *, NSString *) = ^BOOL(NSString *a, NSS
                         [weakSelf.compoundDisposable addDisposable:disposable];
                     }];
 
-                  UIAlertAction *cancelAction = [UIAlertAction
-                                                 actionWithTitle:NSLocalizedStringWithDefaultValue(@"CANCEL_BUTTON", nil, [NSBundle mainBundle], @"Cancel", @"Alert Cancel button")
-                                                 style:UIAlertActionStyleCancel
-                                                 handler:^(UIAlertAction *action) {
-                                                     // Do nothing
-                                                 }];
-
-                  [alert addAction:disableAction];
-                  [alert addAction:cancelAction];
+                  [alert addAction:stopUntilNextStartAction];
                   [self presentViewController:alert animated:TRUE completion:nil];
-
               }
 
               [self removePulsingHaloLayer];

--- a/Psiphon/SettingsViewController.h
+++ b/Psiphon/SettingsViewController.h
@@ -18,9 +18,6 @@
  */
 
 #import "PsiphonSettingsViewController.h"
-#import "UserDefaults.h"
-
-FOUNDATION_EXPORT UserDefaultsKey const SettingsConnectOnDemandBoolKey;
 
 @interface SettingsViewController : PsiphonSettingsViewController
 

--- a/Psiphon/SettingsViewController.m
+++ b/Psiphon/SettingsViewController.m
@@ -27,14 +27,6 @@
 #import "RACReplaySubject.h"
 #import "RACSignal+Operations.h"
 
-// NSUserDefaults keys
-/**
- * SettingsConnectOnDemandBoolKey represents user's preference for Connect On Demand.
- * This preference should not be displayed to the user directly, and only the VPN configuration
- * saved Connect On Demand value should be displayed to user.
- */
-UserDefaultsKey const SettingsConnectOnDemandBoolKey = @"SettingsViewController.ConnectOnDemandKey";
-
 // Specifier keys for cells in settings menu
 // These keys are defined in Psiphon/InAppSettings.bundle/Root.inApp.plist
 NSString * const SettingsSubscriptionCellSpecifierKey = @"settingsSubscription";
@@ -210,8 +202,6 @@ NSString * const ConnectOnDemandCellSpecifierKey = @"vpnOnDemand";
 
 - (void)toggledVpnOnDemandValue:(id)sender {
     UISwitch *toggle = (UISwitch*)sender;
-
-    [[NSUserDefaults standardUserDefaults] setBool:[toggle isOn] forKey:SettingsConnectOnDemandBoolKey];
 
     __weak SettingsViewController *weakSelf = self;
 

--- a/Psiphon/VPNManager.h
+++ b/Psiphon/VPNManager.h
@@ -19,6 +19,7 @@
 
 #import <Foundation/Foundation.h>
 #import <NetworkExtension/NetworkExtension.h>
+#import "UserDefaults.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -27,6 +28,13 @@ NS_ASSUME_NONNULL_BEGIN
 @class RACTwoTuple<__covariant First, __covariant Second>;
 
 FOUNDATION_EXPORT NSErrorDomain const VPNManagerErrorDomain;
+
+/**
+ * VPNManagerConnectOnDemandUntilNextStartBoolKey represents user's preference for Connect On Demand to be enabled
+ * for the next VPN start.
+ * This preference should not be displayed to the user directly.
+ */
+FOUNDATION_EXPORT UserDefaultsKey const VPNManagerConnectOnDemandUntilNextStartBoolKey;
 
 typedef NS_ERROR_ENUM(VPNManagerErrorDomain, VPNManagerConfigErrorCode) {
     /*! @const VPNManagerStartErrorConfigLoadFailed Failed to load VPN configurations. */

--- a/Psiphon/VPNManager.m
+++ b/Psiphon/VPNManager.m
@@ -45,6 +45,8 @@ NSErrorDomain const VPNManagerErrorDomain = @"VPNManagerErrorDomain";
 
 PsiFeedbackLogType const VPNManagerLogType = @"VPNManager";
 
+UserDefaultsKey const VPNManagerConnectOnDemandUntilNextStartBoolKey = @"VPNManager.ConnectOnDemandUntilNextStartKey";
+
 @interface VPNManager ()
 
 // Public properties
@@ -218,11 +220,6 @@ PsiFeedbackLogType const VPNManagerLogType = @"VPNManager";
           subscribeNext:^(NETunnelProviderManager *tunnelProvider) {
               if (tunnelProvider) {
                   instance.tunnelProviderManager = tunnelProvider;
-
-                  // If Connect On Demand setting was changed since the last time the app was opened,
-                  // reset user's preference to the same state as the VPN Configuration.
-                  [[NSUserDefaults standardUserDefaults]
-                    setBool:instance.tunnelProviderManager.isOnDemandEnabled forKey:SettingsConnectOnDemandBoolKey];
               }
           }
           error:^(NSError *error) {
@@ -326,6 +323,14 @@ PsiFeedbackLogType const VPNManagerLogType = @"VPNManager";
           if (!providerManager.onDemandRules || [providerManager.onDemandRules count] == 0) {
               NEOnDemandRule *alwaysConnectRule = [NEOnDemandRuleConnect new];
               providerManager.onDemandRules = @[alwaysConnectRule];
+          }
+
+          NSUserDefaults *ud = [NSUserDefaults standardUserDefaults];
+          if ([ud boolForKey:VPNManagerConnectOnDemandUntilNextStartBoolKey]) {
+              providerManager.onDemandEnabled = TRUE;
+
+              // Reset VPNManagerConnectOnDemandUntilNextStartBoolKey value.
+              [ud setBool:FALSE forKey:VPNManagerConnectOnDemandUntilNextStartBoolKey];
           }
 
           return providerManager;

--- a/Shared/Strings/en.lproj/Localizable.strings
+++ b/Shared/Strings/en.lproj/Localizable.strings
@@ -27,9 +27,6 @@
 /* Buy subscription dialog footer text */
 "BUY_SUBSCRIPTIONS_NOTICES" = "A subscription is auto-renewable which means that once purchased it will be automatically renewed until you cancel it 24 hours prior to the end of the current period.\n\nYour iTunes Account will be charged for renewal within 24-hours prior to the end of the current period with the cost of subscription.";
 
-/* Alert Cancel button */
-"CANCEL_BUTTON" = "Cancel";
-
 /* Alert message informing user that their subscription has expired or that they're not a subscriber, therefore Psiphon can only be started from the Psiphon app. DO NOT translate 'Psiphon'. */
 "CANNOT_START_TUNNEL_DUE_TO_SUBSCRIPTION" = "Your Psiphon subscription has expired.\nSince you're not a subscriber or your subscription has expired, Psiphon can only be started from the Psiphon app.\n\nPlease open the Psiphon app.";
 
@@ -39,8 +36,8 @@
 /* Main text in the 'Upstream Proxy Error' dialog box. This is shown when the user has directly altered these settings, and those settings are (probably) erroneous. DO NOT translate 'Psiphon'. */
 "CHECK_UPSTREAM_PROXY_SETTING" = "You have configured Psiphon to use an upstream proxy.\nHowever, we seem to be unable to connect to a Psiphon server through that proxy.\nPlease fix the settings and try again.";
 
-/* Alert dialog body informing the user that the 'Auto-start VPN on demand' feature is enabled and that the VPN cannot be stopped. Followed by asking the user if they would like to disable the 'Auto-start VPN on demand' feature, and stop the VPN. */
-"CONNECT_ON_DEMAND_ALERT_BODY" = "Cannot stop the VPN while \"Auto-start VPN\" is enabled.\nWould you like to disable \"Auto-start VPN\" on demand and stop the VPN?";
+/* Alert dialog body informing the user that the 'Auto-start VPN on demand' feature will be disabled and that the VPN cannot be stopped. */
+"CONNECT_ON_DEMAND_ALERT_BODY" = "\"Auto-start VPN\" will be temporarily disabled until the next time Psiphon VPN is started.";
 
 /* Alert dialog title informing user that 'Auto-start VPN' feature is enabled */
 "CONNECT_ON_DEMAND_ALERT_TITLE" = "Auto-start VPN is enabled";
@@ -50,9 +47,6 @@
 
 /* Alert dialog message informing the user that the settings file in the app is corrupt, and that they can potentially fix this issue by re-installing the app. */
 "CORRUPT_SETTINGS_MESSAGE" = "Your app settings file appears to be corrupt. Try reinstalling the app to repair the file.";
-
-/* Disable Auto-start VPN feature and Stop the VPN button label */
-"DISABLE_BUTTON" = "Disable Auto-start VPN and Stop";
 
 /* Title of the button that dismisses region selection dialog
    Title of the button that dismisses the subscriptions menu */
@@ -91,7 +85,8 @@
 /* Subscriptions view text that is visible when the list of subscriptions is not available */
 "NO_PRODUCTS_TEXT" = "Could not retrieve subscriptions from the App Store. Pull to refresh or try again later.";
 
-/* Alert OK Button */
+/* Alert OK Button
+   OK button title */
 "OK_BUTTON" = "OK";
 
 /* Alert message informing the user they should open the app to finish connecting to the VPN. DO NOT translate 'Psiphon'. */


### PR DESCRIPTION
- Instead of presenting user with options, we will default
  to disabling ConnectOnDemand when the stop button is pressed.