### PR TITLE
Added settings menu item to reinstall VPN profile

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -11,7 +11,7 @@ target 'Psiphon' do
   # Pods for Psiphon
   pod "InAppSettingsKit", :git => "https://github.com/Psiphon-Inc/InAppSettingsKit.git", :commit => '598c498'
   #pod "InAppSettingsKit", :path => "../InAppSettingsKit"
-  pod 'PsiphonClientCommonLibrary', :git => "https://github.com/Psiphon-Inc/psiphon-ios-client-common-library.git", :commit => '1a49a0c'
+  pod 'PsiphonClientCommonLibrary', :git => "https://github.com/Psiphon-Inc/psiphon-ios-client-common-library.git", :commit => '9404b40'
   #pod "PsiphonClientCommonLibrary", :path => "../psiphon-ios-client-common-library"
 
   pod 'ReactiveObjC', :git => "https://github.com/Psiphon-Inc/ReactiveObjC.git", :commit => 'b2ac770'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -15,7 +15,7 @@ PODS:
     - mopub-ios-sdk/Core
     - mopub-ios-sdk/Moat
   - OpenSSL (1.0.210)
-  - PsiphonClientCommonLibrary (1.0.1):
+  - PsiphonClientCommonLibrary (1.1.0):
     - InAppSettingsKit
   - PureLayout (3.0.2)
   - ReactiveObjC (3.1.0)
@@ -28,7 +28,7 @@ DEPENDENCIES:
   - MBProgressHUD (~> 1.1.0)
   - mopub-ios-sdk (= 4.18.0)
   - OpenSSL (= 1.0.210)
-  - PsiphonClientCommonLibrary (from `https://github.com/Psiphon-Inc/psiphon-ios-client-common-library.git`, commit `1a49a0c`)
+  - PsiphonClientCommonLibrary (from `https://github.com/Psiphon-Inc/psiphon-ios-client-common-library.git`, commit `9404b40`)
   - PureLayout (= 3.0.2)
   - ReactiveObjC (from `https://github.com/Psiphon-Inc/ReactiveObjC.git`, commit `b2ac770`)
   - VungleSDK-iOS (= 5.3.0)
@@ -38,7 +38,7 @@ EXTERNAL SOURCES:
     :commit: 598c498
     :git: https://github.com/Psiphon-Inc/InAppSettingsKit.git
   PsiphonClientCommonLibrary:
-    :commit: 1a49a0c
+    :commit: 9404b40
     :git: https://github.com/Psiphon-Inc/psiphon-ios-client-common-library.git
   ReactiveObjC:
     :commit: b2ac770
@@ -49,7 +49,7 @@ CHECKOUT OPTIONS:
     :commit: 598c498
     :git: https://github.com/Psiphon-Inc/InAppSettingsKit.git
   PsiphonClientCommonLibrary:
-    :commit: 1a49a0c
+    :commit: 9404b40
     :git: https://github.com/Psiphon-Inc/psiphon-ios-client-common-library.git
   ReactiveObjC:
     :commit: b2ac770
@@ -62,11 +62,11 @@ SPEC CHECKSUMS:
   MBProgressHUD: e7baa36a220447d8aeb12769bf0585582f3866d9
   mopub-ios-sdk: 043a81e7e3ccd2b888fec35880b13e2876c16ff3
   OpenSSL: 246ffb948e9d56466727fd318134af35f5aa764e
-  PsiphonClientCommonLibrary: 7ecdfd4526f61cc55f80c433169938984d7a89de
+  PsiphonClientCommonLibrary: e03d3547fc8208bdfc7718e4dd7f153665193927
   PureLayout: 4d550abe49a94f24c2808b9b95db9131685fe4cd
   ReactiveObjC: 2a38ea15335de4119d8b17caf1db1484f61db902
   VungleSDK-iOS: af3aa92d0f4a923505a9416646ffef5250592150
 
-PODFILE CHECKSUM: 90162b907b5a41d81b9788c3c1ef72cded602075
+PODFILE CHECKSUM: 6af6b2d28d2d6e812aee5079dc691bcbceee17a2
 
 COCOAPODS: 1.4.0

--- a/Psiphon/InAppSettings.bundle/Root.inApp.plist
+++ b/Psiphon/InAppSettings.bundle/Root.inApp.plist
@@ -5,7 +5,6 @@
 	<key>PreferenceSpecifiers</key>
 	<array>
 		<dict>
-			<!-- Untranslated -->
 			<key>Title</key>
 			<string>Psiphon</string>
 			<key>Type</key>
@@ -235,7 +234,7 @@
 				</dict>
 				<dict>
 					<key>Title</key>
-					<string>O'zbekcha</string>
+					<string>O&apos;zbekcha</string>
 				</dict>
 				<dict>
 					<key>Title</key>
@@ -382,8 +381,18 @@
 			<string>PSGroupSpecifier</string>
 		</dict>
 		<dict>
+			<key>Title</key>
+			<string>!!! Not in the Root.strings, this title is set from SettingsViewController!!!</string>
+			<key>Key</key>
+			<string>settingsReinstallVPNConfiguration</string>
+			<key>Type</key>
+			<string>IASKCustomViewSpecifier</string>
+			<key>DefaultValue</key>
+			<string></string>
+		</dict>
+		<dict>
 			<key>File</key>
-			<string>ConnectionHelp</string>
+			<string>ConnectionHelpVPN</string>
 			<key>BundleTable</key>
 			<string>PsiphonClientCommonLibrary</string>
 			<key>Title</key>

--- a/Psiphon/SettingsViewController.m
+++ b/Psiphon/SettingsViewController.m
@@ -18,20 +18,21 @@
  */
 
 #import "SettingsViewController.h"
+#import "AppDelegate.h"
 #import "IAPStoreHelper.h"
 #import "IAPViewController.h"
-#import "VPNManager.h"
-#import "AppDelegate.h"
 #import "PsiCashOnboardingViewController.h"
 #import "RACSignal.h"
 #import "RACCompoundDisposable.h"
 #import "RACReplaySubject.h"
 #import "RACSignal+Operations.h"
+#import "VPNManager.h"
 
 // Specifier keys for cells in settings menu
 // These keys are defined in Psiphon/InAppSettings.bundle/Root.inApp.plist
 NSString * const SettingsSubscriptionCellSpecifierKey = @"settingsSubscription";
 NSString * const SettingsPsiCashCellSpecifierKey = @"settingsPsiCash";
+NSString * const SettingsReinstallVPNConfigurationKey = @"settingsReinstallVPNConfiguration";
 NSString * const ConnectOnDemandCellSpecifierKey = @"vpnOnDemand";
 
 @interface SettingsViewController ()
@@ -178,36 +179,22 @@ NSString * const ConnectOnDemandCellSpecifierKey = @"vpnOnDemand";
         [self openIAPViewController];
     } else if ([specifier.key isEqualToString:SettingsPsiCashCellSpecifierKey]) {
         [self openPsiCashViewController];
+    } else if ([specifier.key isEqualToString:SettingsReinstallVPNConfigurationKey]) {
+        [[VPNManager sharedInstance] reinstallVPNConfiguration];
     }
 }
 
 - (UITableViewCell*)tableView:(UITableView*)tableView cellForSpecifier:(IASKSpecifier*)specifier {
     UITableViewCell *cell = nil;
-    if (![specifier.key isEqualToString:SettingsSubscriptionCellSpecifierKey]
+    if (![specifier.key isEqualToString:ConnectOnDemandCellSpecifierKey]
         && ![specifier.key isEqualToString:SettingsPsiCashCellSpecifierKey]
-        && ![specifier.key isEqualToString:ConnectOnDemandCellSpecifierKey]) {
+        && ![specifier.key isEqualToString:SettingsReinstallVPNConfigurationKey]
+        && ![specifier.key isEqualToString:SettingsSubscriptionCellSpecifierKey]) {
         cell = [super tableView:tableView cellForSpecifier:specifier];
         return cell;
     }
 
-    if ([specifier.key isEqualToString:SettingsSubscriptionCellSpecifierKey]) {
-
-        cell = [super tableView:tableView cellForSpecifier:specifier];
-        [cell setAccessoryType:UITableViewCellAccessoryDisclosureIndicator];
-        subscriptionTableViewCell = cell;
-        [self updateSubscriptionCell];
-
-    } else if ([specifier.key isEqualToString:SettingsPsiCashCellSpecifierKey]) {
-
-        cell = [super tableView:tableView cellForSpecifier:specifier];
-        [cell setAccessoryType:UITableViewCellAccessoryDisclosureIndicator];
-        [cell.textLabel setText:NSLocalizedStringWithDefaultValue(@"SETTINGS_PSICASH_CELL_TITLE",
-                                                                  nil,
-                                                                  [NSBundle mainBundle],
-                                                                  @"PsiCash",
-                                                                  @"Title of cell in settings menu which, when pressed, launches the PsiCash onboarding")];
-
-    } else if ([specifier.key isEqualToString:ConnectOnDemandCellSpecifierKey]) {
+    if ([specifier.key isEqualToString:ConnectOnDemandCellSpecifierKey]) {
 
         cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:@"Cell"];
         cell.selectionStyle = UITableViewCellSelectionStyleNone;
@@ -222,6 +209,32 @@ NSString * const ConnectOnDemandCellSpecifierKey = @"vpnOnDemand";
                                                                 @"Automatically start VPN On demand settings toggle");
         connectOnDemandCell = cell;
         [self updateConnectOnDemandCell];
+    } else if ([specifier.key isEqualToString:SettingsSubscriptionCellSpecifierKey]) {
+
+        cell = [super tableView:tableView cellForSpecifier:specifier];
+        [cell setAccessoryType:UITableViewCellAccessoryDisclosureIndicator];
+        subscriptionTableViewCell = cell;
+        [self updateSubscriptionCell];
+
+    } else if ([specifier.key isEqualToString:SettingsReinstallVPNConfigurationKey]) {
+
+        cell = [super tableView:tableView cellForSpecifier:specifier];
+        [cell setAccessoryType:UITableViewCellAccessoryNone];
+        [cell.textLabel setText:NSLocalizedStringWithDefaultValue(@"SETTINGS_REINSTALL_VPN_CONFIGURATION_CELL_TITLE",
+                                                                  nil,
+                                                                  [NSBundle mainBundle],
+                                                                  @"Reinstall VPN profile",
+                                                                  @"Title of cell in settings menu which, when pressed, reinstalls the user's VPN profile for Psiphon")];
+    } else if ([specifier.key isEqualToString:SettingsPsiCashCellSpecifierKey]) {
+
+        cell = [super tableView:tableView cellForSpecifier:specifier];
+        [cell setAccessoryType:UITableViewCellAccessoryDisclosureIndicator];
+        [cell.textLabel setText:NSLocalizedStringWithDefaultValue(@"SETTINGS_PSICASH_CELL_TITLE",
+                                                                  nil,
+                                                                  [NSBundle mainBundle],
+                                                                  @"PsiCash",
+                                                                  @"Title of cell in settings menu which, when pressed, launches the PsiCash onboarding")];
+
     }
 
     assert(cell != nil);

--- a/Shared/Strings/en.lproj/Localizable.strings
+++ b/Shared/Strings/en.lproj/Localizable.strings
@@ -251,6 +251,9 @@
 /* Title of cell in settings menu which, when pressed, launches the PsiCash onboarding */
 "SETTINGS_PSICASH_CELL_TITLE" = "PsiCash";
 
+/* Title of cell in settings menu which, when pressed, reinstalls the user's VPN profile for Psiphon */
+"SETTINGS_REINSTALL_VPN_CONFIGURATION_CELL_TITLE" = "Reinstall VPN profile";
+
 /* Subscriptions item title in the app settings when user has an active subscription. Clicking this item opens subscriptions view */
 "SETTINGS_SUBSCRIPTION_ACTIVE" = "Subscriptions";
 


### PR DESCRIPTION
A button has been added to allow the user to reinstall Psiphon's VPN profile. This is useful in the rare scenario where the existing profile is corrupted. This has only been observed in testing.