### PR TITLE
Fix AdManager only trying to initialize Ad SDK once

### DIFF
--- a/Psiphon/Ad/AdManager.h
+++ b/Psiphon/Ad/AdManager.h
@@ -108,11 +108,11 @@ typedef NS_ERROR_ENUM(AdControllerWrapperErrorDomain, AdControllerWrapperErrorCo
 // side-effects (even if the ad has already been loaded).
 // Returned signal is expected to terminate with an error when an ad expires or fails to load, with the appropriate
 // `AdControllerWrapperErrorCode` error code.
-- (RACSignal<NSString *> *)loadAd;
+- (RACSignal<AdControllerTag> *)loadAd;
 
 // Unloads ad if one is loaded. `ready` should be FALSE after the unloading is done.
 // Implementations should emit the wrapper's tag after ad is unloaded and then complete.
-- (RACSignal<NSString *> *)unloadAd;
+- (RACSignal<AdControllerTag> *)unloadAd;
 
 @optional
 

--- a/Psiphon/Ad/AdManager.m
+++ b/Psiphon/Ad/AdManager.m
@@ -317,6 +317,7 @@ typedef NS_ENUM(NSInteger, AdLoadAction) {
                             // MoPub consent dialog was presented successfully and dismissed
                             // or consent is already given or is not needed.
                             // We can start loading ads.
+                            [PsiFeedbackLogger infoWithType:AdManagerLogType message:@"adSDKInitSucceeded"];
                             [subscriber sendNext:RACUnit.defaultUnit];
                             [subscriber sendCompleted];
                         }];

--- a/Psiphon/Ad/AdMobConsent.h
+++ b/Psiphon/Ad/AdMobConsent.h
@@ -20,6 +20,8 @@
 #import <Foundation/Foundation.h>
 #import <PersonalizedAdConsent/PersonalizedAdConsent.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface AdMobConsent : NSObject
 
 /**
@@ -33,3 +35,5 @@
                withCompletionHandler:(void (^_Nonnull)(NSError *_Nullable error, PACConsentStatus s))completion;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Psiphon/Ad/InterstitialAdControllerWrapper.m
+++ b/Psiphon/Ad/InterstitialAdControllerWrapper.m
@@ -43,7 +43,7 @@ PsiFeedbackLogType const InterstitialAdControllerWrapperLogType = @"Interstitial
 @property (nonatomic, readwrite, nullable) MPInterstitialAdController *interstitial;
 
 /** loadStatus is hot non-completing signal - emits the wrapper tag when the ad has been loaded. */
-@property (nonatomic, readwrite, nonnull) RACSubject<NSString *> *loadStatus;
+@property (nonatomic, readwrite, nonnull) RACSubject<AdControllerTag> *loadStatus;
 
 @property (nonatomic, readonly) NSString *adUnitID;
 
@@ -67,7 +67,7 @@ PsiFeedbackLogType const InterstitialAdControllerWrapperLogType = @"Interstitial
     [MPInterstitialAdController removeSharedInterstitialAdController:self.interstitial];
 }
 
-- (RACSignal<NSString *> *)loadAd {
+- (RACSignal<AdControllerTag> *)loadAd {
 
     InterstitialAdControllerWrapper *__weak weakSelf = self;
 
@@ -91,7 +91,7 @@ PsiFeedbackLogType const InterstitialAdControllerWrapperLogType = @"Interstitial
     }];
 }
 
-- (RACSignal<NSString *> *)unloadAd {
+- (RACSignal<AdControllerTag> *)unloadAd {
 
     InterstitialAdControllerWrapper *__weak weakSelf = self;
 

--- a/Psiphon/Ad/MoPubConsent.h
+++ b/Psiphon/Ad/MoPubConsent.h
@@ -19,6 +19,7 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
 
 @interface MoPubConsent : NSObject
 
@@ -30,3 +31,5 @@
 + (void)collectConsentWithCompletionHandler:(void (^)(NSError *_Nullable error))completion;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Psiphon/Ad/RewardedAdControllerWrapper.h
+++ b/Psiphon/Ad/RewardedAdControllerWrapper.h
@@ -22,6 +22,8 @@
 #import <mopub-ios-sdk/MPRewardedVideo.h>
 #import "AdManager.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface RewardedAdControllerWrapper : NSObject <AdControllerWrapperProtocol>
 
 - (instancetype)initWithAdUnitID:(NSString *)adUnitID withTag:(AdControllerTag)tag;
@@ -30,3 +32,5 @@
                                         withCustomData:(NSString *_Nullable)customData;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Psiphon/Ad/RewardedAdControllerWrapper.m
+++ b/Psiphon/Ad/RewardedAdControllerWrapper.m
@@ -38,7 +38,7 @@ PsiFeedbackLogType const RewardedAdControllerWrapperLogType = @"RewardedAdContro
 
 // Private Properties.
 /** loadStatus is hot non-completing signal - emits the wrapper tag when the ad has been loaded. */
-@property (nonatomic, readwrite, nonnull) RACSubject<NSString *> *loadStatus;
+@property (nonatomic, readwrite, nonnull) RACSubject<AdControllerTag> *loadStatus;
 
 /** Hot terminating signal - emits items of type @(AdPresentation). */
 @property (nonatomic, nullable) RACSubject<NSNumber *> *presentationStatus;
@@ -65,7 +65,7 @@ PsiFeedbackLogType const RewardedAdControllerWrapperLogType = @"RewardedAdContro
     [MPRewardedVideo removeDelegate:self];
 }
 
-- (RACSignal<NSString *> *)loadAd {
+- (RACSignal<AdControllerTag> *)loadAd {
 
     RewardedAdControllerWrapper *__weak weakSelf = self;
 
@@ -80,7 +80,7 @@ PsiFeedbackLogType const RewardedAdControllerWrapperLogType = @"RewardedAdContro
     }];
 }
 
-- (RACSignal<NSString *> *)unloadAd {
+- (RACSignal<AdControllerTag> *)unloadAd {
 
     RewardedAdControllerWrapper *__weak weakSelf = self;
 

--- a/Psiphon/IAPHelpViewController.m
+++ b/Psiphon/IAPHelpViewController.m
@@ -228,8 +228,6 @@
 - (void)onPaymentTransactionUpdate:(NSNotification *)notification {
     SKPaymentTransactionState transactionState = (SKPaymentTransactionState) [notification.userInfo[IAPHelperPaymentTransactionUpdateKey] integerValue];
 
-    LOG_DEBUG(@"test transaction state %ld", (long)transactionState);
-    
     if (SKPaymentTransactionStatePurchasing == transactionState) {
         [self showProgressSpinnerAndBlockUI];
     } else {

--- a/Psiphon/PsiCash/Views/PsiCashRewardedVideoBar.m
+++ b/Psiphon/PsiCash/Views/PsiCashRewardedVideoBar.m
@@ -80,8 +80,11 @@
     status.textAlignment = NSTextAlignmentCenter;
     status.textColor = [UIColor whiteColor];
     status.userInteractionEnabled = NO;
-    
-    status.text = @"Watch a video to earn PsiCash!";
+
+    status.text = NSLocalizedStringWithDefaultValue(@"REWARDED_VIDEO_EARN_PSICASH", nil, [NSBundle mainBundle],
+      @"Watch a video to earn PsiCash!",
+      @"Button label indicating to the user that they will earn PsiCash if they watch a video advertisement."
+      " The word 'PsiCash' should not be translated or transliterated.");
 
     // Assume at first that a video has not been loaded
     [self videoReady:NO];

--- a/Shared/Strings/en.lproj/Localizable.strings
+++ b/Shared/Strings/en.lproj/Localizable.strings
@@ -250,6 +250,9 @@
 /* Title of button which triggers an attempt to restore the user's existing subscription */
 "RESTORE_SUBSCRIPTION_BUTTON_TITLE" = "Restore my subscription";
 
+/* Button label indicating to the user that they will earn PsiCash if they watch a video advertisement. The word 'PsiCash' should not be translated or transliterated. */
+"REWARDED_VIDEO_EARN_PSICASH" = "Watch a video to earn PsiCash!";
+
 /* Title of cell in settings menu which, when pressed, reinstalls the user's VPN profile for Psiphon */
 "SETTINGS_REINSTALL_VPN_CONFIGURATION_CELL_TITLE" = "Reinstall VPN profile";
 


### PR DESCRIPTION
- App events are now monitored to decide when to start
  initializing Ad SDKs and collect conset from the user
  (if applicable).