### PR TITLE
Fix AdManager feedback logging

### DIFF
--- a/Shared/PsiFeedbackLogger.h
+++ b/Shared/PsiFeedbackLogger.h
@@ -46,6 +46,8 @@ typedef NSString * PsiFeedbackLogType;
 
 + (void)warnWithType:(PsiFeedbackLogType)sourceType message:(NSString *)message object:(NSError *)error;
 
++ (void)warnWithType:(PsiFeedbackLogType)sourceType json:(NSDictionary*_Nonnull)json;
+
 + (void)error:(NSString *)format, ... NS_FORMAT_FUNCTION(1,2);
 
 + (void)errorWithType:(PsiFeedbackLogType)sourceType message:(NSString *)format, ... NS_FORMAT_FUNCTION(2,3);

--- a/Shared/PsiFeedbackLogger.m
+++ b/Shared/PsiFeedbackLogger.m
@@ -207,6 +207,15 @@ PsiFeedbackLogType const FeedbackInternalLogType = @"FeedbackLoggerInternal";
 
 }
 
++ (void)warnWithType:(PsiFeedbackLogType)sourceType json:(NSDictionary *_Nonnull)json {
+    NSDictionary *data = @{sourceType : json};
+    [[PsiFeedbackLogger sharedInstance] writeData:data noticeType:ErrorNoticeType];
+
+#if DEBUG
+    NSLog(@"<WARN> %@", data);
+#endif
+}
+
 + (void)error:(NSString *)format, ... {
 
     NSString *message;


### PR DESCRIPTION
- AdManager incorrectly logged all ad events as "adDidLoad"