### PR TITLE
Fix: Bengali and Tibetan keys swapped

### DIFF
--- a/Psiphon/InAppSettings.bundle/Root.inApp.plist
+++ b/Psiphon/InAppSettings.bundle/Root.inApp.plist
@@ -134,11 +134,11 @@
 				</dict>
 				<dict>
 					<key>Title</key>
-					<string>বাংলা</string>
+					<string>བོད་ཡིག</string>
 				</dict>
 				<dict>
 					<key>Title</key>
-					<string>བོད་ཡིག</string>
+					<string>বাংলা</string>
 				</dict>
 				<dict>
 					<key>Title</key>


### PR DESCRIPTION
Fixes bug where selecting Bengali resulted in Tibetan translations and vice versa