### PR TITLE
Require user to accept privacy policy; add cancel subscription instructions

### DIFF
--- a/Psiphon/IAPViewController.m
+++ b/Psiphon/IAPViewController.m
@@ -322,11 +322,20 @@ static NSString *iapCellID = @"IAPTableCellID";
     label.numberOfLines = 0;
     label.font = [label.font fontWithSize:15];
     label.textColor = UIColor.whiteColor;
-    label.text = NSLocalizedStringWithDefaultValue(@"BUY_SUBSCRIPTIONS_FOOTER_TEXT",
+
+    NSString *footerText = NSLocalizedStringWithDefaultValue(@"BUY_SUBSCRIPTIONS_FOOTER_TEXT",
                                                    nil,
                                                    [NSBundle mainBundle],
                                                    @"A subscription is auto-renewable which means that once purchased it will be automatically renewed until you cancel it 24 hours prior to the end of the current period.\n\nYour iTunes Account will be charged for renewal within 24-hours prior to the end of the current period with the cost of the subscription.",
                                                    @"Buy subscription dialog footer text");
+
+    NSString * cancelInstructions = NSLocalizedStringWithDefaultValue(@"BUY_SUBSCRIPTIONS_FOOTER_CANCEL_INSTRUCTIONS_TEXT",
+                                                                      nil,
+                                                                      [NSBundle mainBundle],
+                                                                      @"You can cancel an active subscription in your iTunes Account Settings.",
+                                                                      @"Buy subscription dialog footer text explaining where the user can cancel an active subscription");
+
+    label.text = [NSString stringWithFormat:@"%@\n\n%@", footerText, cancelInstructions];
 
     label.textAlignment = NSTextAlignmentLeft;
     [cell.contentView addSubview:label];

--- a/Psiphon/PrivacyPolicyViewController.m
+++ b/Psiphon/PrivacyPolicyViewController.m
@@ -366,19 +366,19 @@ typedef NS_ERROR_ENUM(PrivacyPolicyErrorDomain, PrivacyPolicyLinkGenerationError
 # pragma mark - UI Callbacks
 
 - (void)onGetStartedTap {
-    [[NSNotificationCenter defaultCenter] postNotificationName:PrivacyPolicyDismissedNotification
-                                                        object:nil
-                                      userInfo:@{PrivacyPolicyAcceptedNotificationBoolKey : @TRUE}];
-
-    [self dismissViewControllerAnimated:TRUE completion:nil];
+    [self dismissViewControllerAnimated:TRUE completion:^{
+        [[NSNotificationCenter defaultCenter] postNotificationName:PrivacyPolicyDismissedNotification
+                                                            object:nil
+                                                          userInfo:@{PrivacyPolicyAcceptedNotificationBoolKey : @TRUE}];
+    }];
 }
 
 - (void)onCancelTap {
-    [[NSNotificationCenter defaultCenter] postNotificationName:PrivacyPolicyDismissedNotification
-                                                        object:nil
-                                     userInfo:@{PrivacyPolicyAcceptedNotificationBoolKey : @FALSE}];
-
-    [self dismissViewControllerAnimated:TRUE completion:nil];
+    [self dismissViewControllerAnimated:TRUE completion:^{
+        [[NSNotificationCenter defaultCenter] postNotificationName:PrivacyPolicyDismissedNotification
+                                                            object:nil
+                                                          userInfo:@{PrivacyPolicyAcceptedNotificationBoolKey : @FALSE}];
+    }];
 }
 
 /***

--- a/Shared/Strings/en.lproj/Localizable.strings
+++ b/Shared/Strings/en.lproj/Localizable.strings
@@ -24,6 +24,9 @@
 /* Title of button on alert view which shows the progress of the user's buy request. Hitting this button dismisses the alert and the buy request continues processing in the background. */
 "BUY_REQUEST_PROGRESS_ALERT_DISMISS_BUTTON_TITLE" = "Dismiss";
 
+/* Buy subscription dialog footer text explaining where the user can cancel an active subscription */
+"BUY_SUBSCRIPTIONS_FOOTER_CANCEL_INSTRUCTIONS_TEXT" = "You can cancel an active subscription in your iTunes Account Settings.";
+
 /* Buy subscription dialog footer text */
 "BUY_SUBSCRIPTIONS_FOOTER_TEXT" = "A subscription is auto-renewable which means that once purchased it will be automatically renewed until you cancel it 24 hours prior to the end of the current period.\n\nYour iTunes Account will be charged for renewal within 24-hours prior to the end of the current period with the cost of the subscription.";
 


### PR DESCRIPTION
- User must accept privacy policy before they can view subscription options (also: region selection and PsiCash onboarding)
- Added instructions detailing how the user can cancel an active subscription