### PR TITLE
Fix waiting for VPN start command if user is subscribed

### DIFF
--- a/PsiphonVPN/PacketTunnelProvider.m
+++ b/PsiphonVPN/PacketTunnelProvider.m
@@ -509,7 +509,8 @@ typedef NS_ENUM(NSInteger, TunnelProviderState) {
         || self.extensionStartMethod == ExtensionStartMethodFromCrash
         || [self.subscriptionCheckState isSubscribedOrInProgress]) {
 
-        if (self.extensionStartMethod == ExtensionStartMethodFromContainer) {
+        if (![self.subscriptionCheckState isSubscribedOrInProgress] &&
+            self.extensionStartMethod == ExtensionStartMethodFromContainer) {
             self.waitForContainerStartVPNCommand = TRUE;
         }
 


### PR DESCRIPTION
- This fixes the "Please open the Psiphon app to finish connecting" prompt, when they start the app from the container and background it before the VPN is connected.