### PR TITLE
Don't show alert when pollForBalanceIncrease fails

### DIFF
--- a/Psiphon/PsiCash/ClientWrapper/PsiCashClient.m
+++ b/Psiphon/PsiCash/ClientWrapper/PsiCashClient.m
@@ -283,8 +283,6 @@ typedef NS_ERROR_ENUM(PsiCashClientRefreshStateErrorDomain, PsiCashClientRefresh
         [logger logErrorEvent:[tag stringByAppendingString:@"Failed"]
                         withError:error
           includingDiagnosticInfo:NO];
-
-        [self displayAlertWithMessage:NSLocalizedStringWithDefaultValue(@"PSICASH_REFRESH_STATE_FAILED_MESSAGE_TEXT", nil, [NSBundle mainBundle], @"Failed to update PsiCash state", @"Alert error message informing user that the app failed to retrieve their PsiCash information from the server. Note: 'PsiCash' should not be translated or transliterated.")];
     } completed:^{
         [logger logEvent:[tag stringByAppendingString:@"Completed"] includingDiagnosticInfo:YES];
     }];

--- a/Shared/Strings/en.lproj/Localizable.strings
+++ b/Shared/Strings/en.lproj/Localizable.strings
@@ -227,9 +227,6 @@
 /* Title text on the third PsiCash onboarding screen. 'Speed Boost' is a reward that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */
 "PSICASH_ONBOARDING_PAGE_3_TITLE" = "Speed Boost";
 
-/* Alert error message informing user that the app failed to retrieve their PsiCash information from the server. Note: 'PsiCash' should not be translated or transliterated. */
-"PSICASH_REFRESH_STATE_FAILED_MESSAGE_TEXT" = "Failed to update PsiCash state";
-
 /* Text which appears in the Speed Boost meter when the user has activated Speed Boost. Please keep this text concise as the width of the text box is restricted in size. 'Speed Boost' is a reward that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */
 "PSICASH_SPEED_BOOST_ACTIVE_TEXT" = "Speed Boost Active";
 


### PR DESCRIPTION
- This alert does not convey any useful or actionable information
  to the user.