### PR TITLE
Fix ad ready to present signal

### DIFF
--- a/Psiphon/Ad/AdControllerWrapper.h
+++ b/Psiphon/Ad/AdControllerWrapper.h
@@ -118,12 +118,11 @@ typedef NS_ERROR_ENUM(AdControllerWrapperErrorDomain, AdControllerWrapperErrorCo
 
 /**
  * Hot relay subject. Emits @(TRUE) if ad is ready to be displayed, @(FALSE) otherwise.
- * The value should not change while the ad is being presented, and should only emit @(FALSE) after
- * the ad has been dismissed.
+ * The value is expected to change after the ad has started presenting.
  * To avoid unnecessary computation for observers of this property, implementations of this protocol
  * should check the current value before emitting new value.
  */
-@property (nonatomic, readonly) BehaviorRelay<NSNumber *> *canPresentOrPresenting;
+@property (nonatomic, readonly) BehaviorRelay<NSNumber *> *canPresent;
 
 /**
  * presentedAdDismissed is hot infinite signal - emits RACUnit whenever an ad is shown.
@@ -137,7 +136,7 @@ typedef NS_ERROR_ENUM(AdControllerWrapperErrorDomain, AdControllerWrapperErrorCo
 @property (nonatomic, readonly) RACSubject<NSNumber *> *presentationStatus;
 
 /**
- * Loads ad if none is already loaded. `canPresentOrPresenting` will emit @(TRUE) once ad has finished loading
+ * Loads ad if none is already loaded. `canPresent` will relay @(TRUE) once ad has finished loading
  * successfully and is ready to be presented.
  *
  * Implementations should handle multiple subscriptions to the returned signal without
@@ -155,7 +154,7 @@ typedef NS_ERROR_ENUM(AdControllerWrapperErrorDomain, AdControllerWrapperErrorCo
 - (RACSignal<RACTwoTuple<AdControllerTag, NSError *> *> *)loadAd;
 
 /**
- * Unloads ad if one is loaded. `canPresentOrPresenting` will emit @(FALSE) after unloading is done.
+ * Unloads ad if one is loaded. `canPresent` will relay @(FALSE) after unloading is done.
  * Implementations should emit the wrapper's tag after ad is unloaded and then complete.
  *
  * @scheduler: should be subscribed on the main thread.

--- a/Psiphon/Ad/AdManager.m
+++ b/Psiphon/Ad/AdManager.m
@@ -463,7 +463,7 @@ typedef NS_ENUM(NSInteger, AdLoadAction) {
 
               if (appEvent.tunnelState == TunnelStateUntunneled && appEvent.networkIsReachable) {
 
-                  return weakSelf.untunneledInterstitial.canPresentOrPresenting;
+                  return weakSelf.untunneledInterstitial.canPresent;
               }
               return [RACSignal return:@(FALSE)];
           }]
@@ -476,10 +476,10 @@ typedef NS_ENUM(NSInteger, AdLoadAction) {
               if (appEvent.networkIsReachable) {
 
                   if (appEvent.tunnelState == TunnelStateUntunneled) {
-                      return weakSelf.untunneledRewardVideo.canPresentOrPresenting;
+                      return weakSelf.untunneledRewardVideo.canPresent;
 
                   } else if (appEvent.tunnelState == TunnelStateTunneled) {
-                      return weakSelf.tunneledRewardVideo.canPresentOrPresenting;
+                      return weakSelf.tunneledRewardVideo.canPresent;
                   }
               }
 

--- a/Psiphon/Ad/MoPubRewardedAdControllerWrapper.m
+++ b/Psiphon/Ad/MoPubRewardedAdControllerWrapper.m
@@ -33,7 +33,7 @@ PsiFeedbackLogType const MoPubRewardedAdControllerWrapperLogType = @"MoPubReward
 
 @interface MoPubRewardedAdControllerWrapper () <MPRewardedVideoDelegate>
 
-@property (nonatomic, readwrite, nonnull) BehaviorRelay<NSNumber *> *canPresentOrPresenting;
+@property (nonatomic, readwrite, nonnull) BehaviorRelay<NSNumber *> *canPresent;
 
 /** presentedAdDismissed is hot infinite signal - emits RACUnit whenever an ad is presented. */
 @property (nonatomic, readwrite, nonnull) RACSubject<RACUnit *> *presentedAdDismissed;
@@ -58,7 +58,7 @@ PsiFeedbackLogType const MoPubRewardedAdControllerWrapperLogType = @"MoPubReward
     _tag = tag;
     _loadStatusRelay = [RelaySubject subject];
     _adUnitID = adUnitID;
-    _canPresentOrPresenting = [BehaviorRelay behaviorSubjectWithDefaultValue:@(FALSE)];
+    _canPresent = [BehaviorRelay behaviorSubjectWithDefaultValue:@(FALSE)];
     _presentedAdDismissed = [RACSubject subject];
     _presentationStatus = [RACSubject subject];
     return self;
@@ -90,8 +90,8 @@ PsiFeedbackLogType const MoPubRewardedAdControllerWrapperLogType = @"MoPubReward
     return [RACSignal createSignal:^RACDisposable *(id <RACSubscriber> subscriber) {
         // Unlike interstitials, MoPub SDK doesn't provide a way to destroy the pre-fetched rewarded video ads.
 
-        if ([[weakSelf.canPresentOrPresenting first] boolValue]) {
-            [weakSelf.canPresentOrPresenting accept:@(FALSE)];
+        if ([[weakSelf.canPresent first] boolValue]) {
+            [weakSelf.canPresent accept:@(FALSE)];
         }
 
         [subscriber sendNext:[RACTwoTuple pack:weakSelf.tag :nil]];
@@ -147,8 +147,8 @@ PsiFeedbackLogType const MoPubRewardedAdControllerWrapperLogType = @"MoPubReward
     if (self.adUnitID != adUnitID) {
         return;
     }
-    if (![[self.canPresentOrPresenting first] boolValue]) {
-        [self.canPresentOrPresenting accept:@(TRUE)];
+    if (![[self.canPresent first] boolValue]) {
+        [self.canPresent accept:@(TRUE)];
     }
     [self.loadStatusRelay accept:[RACTwoTuple pack:self.tag :nil]];
 }
@@ -157,8 +157,8 @@ PsiFeedbackLogType const MoPubRewardedAdControllerWrapperLogType = @"MoPubReward
     if (self.adUnitID != adUnitID) {
         return;
     }
-    if ([[self.canPresentOrPresenting first] boolValue]) {
-        [self.canPresentOrPresenting accept:@(FALSE)];
+    if ([[self.canPresent first] boolValue]) {
+        [self.canPresent accept:@(FALSE)];
     }
 
     NSError *e = [NSError errorWithDomain:AdControllerWrapperErrorDomain
@@ -172,8 +172,8 @@ PsiFeedbackLogType const MoPubRewardedAdControllerWrapperLogType = @"MoPubReward
     if (self.adUnitID != adUnitID) {
         return;
     }
-    if ([[self.canPresentOrPresenting first] boolValue]) {
-        [self.canPresentOrPresenting accept:@(FALSE)];
+    if ([[self.canPresent first] boolValue]) {
+        [self.canPresent accept:@(FALSE)];
     }
 
     NSError *e = [NSError errorWithDomain:AdControllerWrapperErrorDomain
@@ -187,8 +187,8 @@ PsiFeedbackLogType const MoPubRewardedAdControllerWrapperLogType = @"MoPubReward
         return;
     }
 
-    if ([[self.canPresentOrPresenting first] boolValue]) {
-        [self.canPresentOrPresenting accept:@(FALSE)];
+    if ([[self.canPresent first] boolValue]) {
+        [self.canPresent accept:@(FALSE)];
     }
 
     [self.presentationStatus sendNext:@(AdPresentationErrorFailedToPlay)];
@@ -198,6 +198,8 @@ PsiFeedbackLogType const MoPubRewardedAdControllerWrapperLogType = @"MoPubReward
     if (self.adUnitID != adUnitID) {
         return;
     }
+    [self.canPresent accept:@(FALSE)];
+
     [self.presentationStatus sendNext:@(AdPresentationWillAppear)];
 }
 
@@ -218,10 +220,6 @@ PsiFeedbackLogType const MoPubRewardedAdControllerWrapperLogType = @"MoPubReward
 - (void)rewardedVideoAdDidDisappearForAdUnitID:(NSString *)adUnitID {
     if (self.adUnitID != adUnitID) {
         return;
-    }
-
-    if ([[self.canPresentOrPresenting first] boolValue]) {
-        [self.canPresentOrPresenting accept:@(FALSE)];
     }
 
     // Since MoPub SDK states that `rewardedVideoAdShouldRewardForAdUnitID:reward:` delegate callback will not be


### PR DESCRIPTION
- The semantics of `canPresentOrPresenting` is overloaded.
  The value of the flag `canPresent` should be able to change freely whether or not an ad is currently being presented.