### PR TITLE
Fix extension start race condition

### DIFF
--- a/Psiphon/VPNManager.m
+++ b/Psiphon/VPNManager.m
@@ -54,6 +54,7 @@
 #import "DispatchUtils.h"
 #import "RACTargetQueueScheduler.h"
 #import "UnionSerialQueue.h"
+#import "PsiphonDataSharedDB.h"
 
 NSErrorDomain const VPNManagerErrorDomain = @"VPNManagerErrorDomain";
 
@@ -333,7 +334,12 @@ PsiFeedbackLogType const VPNManagerLogType = @"VPNManager";
 
     VPNManager *__weak weakSelf = self;
 
-    __block RACDisposable *disposable = [[[[[[[[VPNManager loadTunnelProviderManager]
+    __block RACDisposable *disposable = [[[[[[[[[VPNManager loadTunnelProviderManager]
+      doNext:^(NETunnelProviderManager *x) {
+          // Store the time where tunnel start is called in shared defaults.
+          PsiphonDataSharedDB *sharedDB = [[PsiphonDataSharedDB alloc] initForAppGroupIdentifier:APP_GROUP_IDENTIFIER];
+          [sharedDB setContainerTunnelStartTime:[NSDate date]];
+      }]
       flattenMap:^RACSignal<NETunnelProviderManager *> *(NETunnelProviderManager *_Nullable pm) {
           // Updates VPN configuration parameters if it already exists,
           // otherwise creates a new VPN configuration.

--- a/Shared/PsiFeedbackLogger.m
+++ b/Shared/PsiFeedbackLogger.m
@@ -209,7 +209,7 @@ PsiFeedbackLogType const FeedbackInternalLogType = @"FeedbackLoggerInternal";
 
 + (void)warnWithType:(PsiFeedbackLogType)sourceType json:(NSDictionary *_Nonnull)json {
     NSDictionary *data = @{sourceType : json};
-    [[PsiFeedbackLogger sharedInstance] writeData:data noticeType:ErrorNoticeType];
+    [[PsiFeedbackLogger sharedInstance] writeData:data noticeType:WarnNoticeType];
 
 #if DEBUG
     NSLog(@"<WARN> %@", data);

--- a/Shared/PsiphonDataSharedDB.h
+++ b/Shared/PsiphonDataSharedDB.h
@@ -87,6 +87,14 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (BOOL)getAppForegroundState;
 
+/**
+ * Last date/time immediately before the extension was last started from the container.
+ * Check where `setContainerTunnelStartTime:` is called to set the last tunnel start time.
+ *
+ * @return NSDate of when tunnel was started by the container. Null if no value is set.
+ */
+- (NSDate *_Nullable)getContainerTunnelStartTime;
+
 #if !(TARGET_IS_EXTENSION)
 
 /**
@@ -96,6 +104,11 @@ NS_ASSUME_NONNULL_BEGIN
  * @return TRUE if change was persisted to disk successfully, FALSE otherwise.
  */
 - (BOOL)updateAppForegroundState:(BOOL)foreground;
+
+/**
+ * Time immediately before the extension is started from the tunnel.
+ */
+- (void)setContainerTunnelStartTime:(NSDate *)startTime;
 
 #endif
 

--- a/Shared/PsiphonDataSharedDB.m
+++ b/Shared/PsiphonDataSharedDB.m
@@ -35,6 +35,8 @@ UserDefaultsKey const ClientRegionStringKey = @"client_region";
 
 UserDefaultsKey const AppForegroundBoolKey = @"app_foreground";
 
+UserDefaultsKey const TunnelStartTimeStringKey = @"tunnel_start_time";
+
 UserDefaultsKey const TunnelSponsorIDStringKey = @"current_sponsor_id";
 
 UserDefaultsKey const ServerTimestampStringKey = @"server_timestamp";
@@ -291,11 +293,24 @@ UserDefaultsKey const DebugPsiphonConnectionStateStringKey = @"PsiphonDataShared
     return [sharedDefaults boolForKey:AppForegroundBoolKey];
 }
 
+- (NSDate *_Nullable)getContainerTunnelStartTime {
+    NSString *_Nullable rfc3339Date = [sharedDefaults stringForKey:TunnelStartTimeStringKey];
+    if (!rfc3339Date) {
+        return nil;
+    }
+
+    return [NSDate fromRFC3339String:rfc3339Date];
+}
+
 - (BOOL)updateAppForegroundState:(BOOL)foreground {
     [sharedDefaults setBool:foreground forKey:AppForegroundBoolKey];
     return [sharedDefaults synchronize];
 }
 
+- (void)setContainerTunnelStartTime:(NSDate *)startTime {
+    NSString *rfc3339Date = [startTime RFC3339String];
+    [sharedDefaults setObject:rfc3339Date forKey:TunnelStartTimeStringKey];
+}
 
 #pragma mark - Extension Data (Data originating in the extension)
 

--- a/Shared/ReactiveExtensions/RACSignal+Operations2.m
+++ b/Shared/ReactiveExtensions/RACSignal+Operations2.m
@@ -280,6 +280,10 @@
 
         LOG_DEBUG(@"%@", [serialQueue debugDescription]);
 
+        if ([serialQueue.operationQueue operationCount] > 2) {
+            [PsiFeedbackLogger warnWithType:@"SerialQueueHighCount" json:[serialQueue feedbackInfo]];
+        }
+
         return compoundDisposable;
     }];
 }

--- a/Shared/ReactiveExtensions/UnionSerialQueue.h
+++ b/Shared/ReactiveExtensions/UnionSerialQueue.h
@@ -38,6 +38,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (instancetype)createWithLabel:(NSString *)label;
 
+- (NSDictionary *)feedbackInfo;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Shared/ReactiveExtensions/UnionSerialQueue.m
+++ b/Shared/ReactiveExtensions/UnionSerialQueue.m
@@ -72,4 +72,26 @@
     return lines;
 }
 
+- (NSDictionary *)feedbackInfo {
+
+    NSUInteger count = self.operationQueue.operationCount;
+    NSMutableArray<NSDictionary<NSString *, NSNumber *> *> *operations = [NSMutableArray arrayWithCapacity:count];
+
+    [self.operationQueue.operations enumerateObjectsUsingBlock:^(__kindof NSOperation *op, NSUInteger idx, BOOL *stop) {
+        operations[idx] = @{
+          @"Class": NSStringFromClass([op class]),
+          @"Name": op.name,
+          @"Finished": NSStringFromBOOL(op.finished),
+          @"Ready": NSStringFromBOOL(op.ready),
+          @"Cancelled": NSStringFromBOOL(op.cancelled),
+          @"Executing": NSStringFromBOOL(op.executing)
+        };
+    }];
+
+    return @{
+      @"Count": @(count),
+      @"Operations": operations
+    };
+}
+
 @end


### PR DESCRIPTION
- If the extension is started by the contianer, a race condition exists where "Connect On Demand" can start the extension before the container. The workaround is to calculate the difference in time from when `startTunnel` is called on the `VPNManager`, and when the extension is started, and make sure the difference falls in an acceptable range.

- Logging warning if the serial queue (that's also used in VPNManager), contains more 3 or more pending operations. This could signal a deadlock, or an undesirably long running operation.