### PR TITLE
Fix privacy policy accepted date stored format

### DIFF
--- a/Psiphon/ContainerDB.h
+++ b/Psiphon/ContainerDB.h
@@ -40,21 +40,21 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Privacy Policy
 
 /**
- * Returns date of last update to Psiphon's Privacy Policy for iOS.
+ * Returns time as Unix time of last update to Psiphon's Privacy Policy for iOS.
  */
-- (NSDate *)privacyPolicyUpdateDate;
+- (NSNumber *)privacyPolicyLastUpdateTime;
 
 /**
- * Returns the date of the privacy policy that was last accepted by the user.
+ * Returns time as Unix time of the privacy policy that was last accepted by the user.
  */
-- (NSDate *_Nullable)lastAcceptedPrivacyPolicy;
+- (NSNumber *_Nullable)lastAcceptedPrivacyPolicy;
 
 /**
- * Stores privacyPolicyDate as the date of the privacy policy that was accepted.
- * Note that this is not the date that the user accepted the privacy policy, but rather,
- * the date that the privacy policy was updated.
+ * Stores privacyPolicyUnixTime as the time that the privacy policy that was accepted.
+ * Note that this is not the time that the user accepted the privacy policy, but rather,
+ * the time that the privacy policy was updated.
  */
-- (void)setAcceptedPrivacyPolicy:(NSDate *)privacyPolicyDate;
+- (void)setAcceptedPrivacyPolicyUnixTime:(NSNumber *)privacyPolicyUnixTime;
 
 /**
  * Sets set of egress regions in standard NSUserDefaults

--- a/Psiphon/ContainerDB.m
+++ b/Psiphon/ContainerDB.m
@@ -44,24 +44,20 @@ UserDefaultsKey const AppInfoLastCFBundleVersionStringKey = @"LastCFBundleVersio
                                             forKey:AppInfoLastCFBundleVersionStringKey];
 }
 
-- (NSDate *)privacyPolicyUpdateDate {
-    return [NSDate fromRFC3339String:@"2018-05-15T19:39:57+00:00"];
+- (NSNumber *)privacyPolicyLastUpdateTime {
+    // Time corresponding to 2018-05-15T19:39:57+00:00
+    return [NSNumber numberWithLongLong:1526413197];
 }
 
-- (NSDate *_Nullable)lastAcceptedPrivacyPolicy {
-    NSString *_Nullable dateString = [NSUserDefaults.standardUserDefaults
-      stringForKey:PrivacyPolicyAcceptedRFC3339StringKey];
+- (NSNumber *_Nullable)lastAcceptedPrivacyPolicy {
+    NSNumber *_Nullable unixTime = [NSUserDefaults.standardUserDefaults
+      objectForKey:PrivacyPolicyAcceptedRFC3339StringKey];
 
-    if (!dateString) {
-        return nil;
-    }
-    
-    return [NSDate fromRFC3339String:dateString];
+    return unixTime;
 }
 
-- (void)setAcceptedPrivacyPolicy:(NSDate *)privacyPolicyDate {
-    NSString *dateString = [privacyPolicyDate RFC3339String];
-    [NSUserDefaults.standardUserDefaults setObject:dateString
+- (void)setAcceptedPrivacyPolicyUnixTime:(NSNumber *)privacyPolicyUnixTime {
+    [NSUserDefaults.standardUserDefaults setObject:privacyPolicyUnixTime
                                             forKey:PrivacyPolicyAcceptedRFC3339StringKey];
 }
 

--- a/Psiphon/ViewControllers/MainViewController.m
+++ b/Psiphon/ViewControllers/MainViewController.m
@@ -181,9 +181,9 @@ NSString * const CommandStopVPN = @"StopVPN";
     // PsiCash and AdManager unless the user has accepted
     // the privacy policy.
     ContainerDB *containerDB = [[ContainerDB alloc] init];
-    NSDate *_Nullable privacyPolicyAcceptedDate = [containerDB lastAcceptedPrivacyPolicy];
-    assert(privacyPolicyAcceptedDate != nil);
-    assert([privacyPolicyAcceptedDate afterOrEqualTo:[containerDB privacyPolicyUpdateDate]]);
+    NSNumber *_Nullable privacyPolicyUnixTime = [containerDB lastAcceptedPrivacyPolicy];
+    assert(privacyPolicyUnixTime != nil);
+    assert([privacyPolicyUnixTime compare:[containerDB privacyPolicyLastUpdateTime]] == NSOrderedSame);
 
     availableServerRegions = [[AvailableServerRegions alloc] init];
     [availableServerRegions sync];

--- a/Psiphon/ViewControllers/OnboardingViewController.m
+++ b/Psiphon/ViewControllers/OnboardingViewController.m
@@ -35,6 +35,7 @@
 #import "LanguageSelectionViewController.h"
 #import "AppDelegate.h"
 #import "CloudsView.h"
+#import "Logging.h"
 
 const int NumPages = 4;
 
@@ -295,8 +296,7 @@ const int NumPages = 4;
 - (void)onPrivacyPolicyAccepted {
     // Stores the privacy policy date that the user accepted.
     ContainerDB *containerDB = [[ContainerDB alloc] init];
-    [containerDB setAcceptedPrivacyPolicy:[containerDB privacyPolicyUpdateDate]];
-
+    [containerDB setAcceptedPrivacyPolicyUnixTime:[containerDB privacyPolicyLastUpdateTime]];
     // Go to next page;
     [self gotoNextPage];
 }

--- a/Psiphon/ViewControllers/RootContainerController.m
+++ b/Psiphon/ViewControllers/RootContainerController.m
@@ -78,10 +78,10 @@
     // If has accepted the latest privacy policy and vpn configuration has been installed,
     // then show this
     ContainerDB *containerDB = [[ContainerDB alloc] init];
-    NSDate *_Nullable privacyPolicyAcceptedDate = [containerDB lastAcceptedPrivacyPolicy];
+    NSNumber *_Nullable lastAcceptedPrivacyUnixTime = [containerDB lastAcceptedPrivacyPolicy];
 
-    if (!privacyPolicyAcceptedDate ||
-        [privacyPolicyAcceptedDate before:[containerDB privacyPolicyUpdateDate]]) {
+    if (!lastAcceptedPrivacyUnixTime ||
+        ([lastAcceptedPrivacyUnixTime compare:[containerDB privacyPolicyLastUpdateTime]] == NSOrderedAscending)) {
         [self switchToOnboarding];
     } else {
         [self switchToMainScreenAndStartVPN:FALSE];


### PR DESCRIPTION
- This updates the privacy policy accepted date stored format to Unix timestamp from RFC3339 format.

- The RFC3339 parsing done by `[NSDate dateWithTimeIntervalSince1970:]` introduces numerical rounding that has caused assertions in production code to fail. Therefore we move away to a more rigid format where no complex parsing is required.

- Error can be found in `1.0.26` release at `Psiphon: 0x104e84000 + 33532`.