### PR TITLE
Fix privacy policy stored flag

### DIFF
--- a/Psiphon/AppUpgrade.m
+++ b/Psiphon/AppUpgrade.m
@@ -63,6 +63,8 @@ PsiFeedbackLogType const AppUpgradeLogType = @"AppUpgrade";
     return firstRunOfVersion;
 }
 
+// For safety and simplicity, only `oldVersionString` is provided here.
+// Should not rely on the current build number, as that build number is not specified yet.
 + (void)handleAppUpgradeFromVersion:(NSString *)oldVersionString {
 
     assert(oldVersionString != nil);

--- a/Psiphon/ContainerDB.h
+++ b/Psiphon/ContainerDB.h
@@ -37,24 +37,53 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)storeCurrentAppVersion:(NSString *)appVersion;
 
+#pragma mark - Onboarding
+
+/**
+ * Returns TRUE if user has finished onboarding, FALSE otherwise.
+ */
+- (BOOL)hasFinishedOnboarding;
+
+/**
+ * Sets internal flag that the user has finished onboarding. `- hasFinishedOnboarding` will return TRUE from now on.
+ */
+- (void)setHasFinishedOnboarding;
+
 #pragma mark - Privacy Policy
 
 /**
- * Returns time as Unix time of last update to Psiphon's Privacy Policy for iOS.
+ * Returns RFC3339 formatted time of last update to Psiphon's Privacy Policy for iOS.
  */
-- (NSNumber *)privacyPolicyLastUpdateTime;
+- (NSString *)privacyPolicyLastUpdateTime;
 
 /**
- * Returns time as Unix time of the privacy policy that was last accepted by the user.
+ * Returns RFC3339 formatted time of the privacy policy that was last accepted by the user.
  */
-- (NSNumber *_Nullable)lastAcceptedPrivacyPolicy;
+- (NSString *_Nullable)lastAcceptedPrivacyPolicy;
 
 /**
- * Stores privacyPolicyUnixTime as the time that the privacy policy that was accepted.
- * Note that this is not the time that the user accepted the privacy policy, but rather,
+ * Returns TRUE if the user has accepted the latest privacy policy, FALSE otherwise.
+ */
+- (BOOL)hasAcceptedLatestPrivacyPolicy;
+
+/**
+ * Stores privacyPolicyTimestamp as the privacy policy that was accepted.
+ *
+ * @note This is not the time that the user accepted the privacy policy, but rather,
+ * the time that the privacy policy was updated.
+ *
+ * @param privacyPolicyTimestamp
+ */
+- (void)setAcceptedPrivacyPolicy:(NSString *)privacyPolicyTimestamp;
+
+/**
+ *
+ * Stores `-privacyPolicyLastUpdateTime` as the privacy policy that was accepted.
+ *
+ * @note This is not the time that the user accepted the privacy policy, but rather,
  * the time that the privacy policy was updated.
  */
-- (void)setAcceptedPrivacyPolicyUnixTime:(NSNumber *)privacyPolicyUnixTime;
+- (void)setAcceptedLatestPrivacyPolicy;
 
 /**
  * Sets set of egress regions in standard NSUserDefaults

--- a/Psiphon/ContainerDB.m
+++ b/Psiphon/ContainerDB.m
@@ -20,16 +20,18 @@
 #import "ContainerDB.h"
 #import "NSDate+PSIDateExtension.h"
 #import "UserDefaults.h"
+#import "Logging.h"
 
 #pragma mark - NSUserDefaultsKey
-
-UserDefaultsKey const PrivacyPolicyAcceptedRFC3339StringKey =
-    @"ContainerDB.PrivacyPolicyAcceptedRFC3339StringKey";
 
 UserDefaultsKey const EmbeddedEgressRegionsStringArrayKey =
     @"embedded_server_entries_egress_regions";  // legacy key
 
 UserDefaultsKey const AppInfoLastCFBundleVersionStringKey = @"LastCFBundleVersion"; // legacy key
+
+UserDefaultsKey const FinishedOnboardingBoolKey = @"ContainerDB.FinishedOnboardingBoolKey";
+
+UserDefaultsKey const PrivacyPolicyAcceptedStringTimeKey = @"ContainerDB.PrivacyPolicyAcceptedStringTimeKey2";
 
 #pragma mark -
 
@@ -44,22 +46,45 @@ UserDefaultsKey const AppInfoLastCFBundleVersionStringKey = @"LastCFBundleVersio
                                             forKey:AppInfoLastCFBundleVersionStringKey];
 }
 
-- (NSNumber *)privacyPolicyLastUpdateTime {
-    // Time corresponding to 2018-05-15T19:39:57+00:00
-    return [NSNumber numberWithLongLong:1526413197];
+#pragma mark -
+
+- (BOOL)hasFinishedOnboarding {
+    return [NSUserDefaults.standardUserDefaults boolForKey:FinishedOnboardingBoolKey];
 }
 
-- (NSNumber *_Nullable)lastAcceptedPrivacyPolicy {
-    NSNumber *_Nullable unixTime = [NSUserDefaults.standardUserDefaults
-      objectForKey:PrivacyPolicyAcceptedRFC3339StringKey];
+- (void)setHasFinishedOnboarding {
+    [NSUserDefaults.standardUserDefaults setBool:TRUE forKey:FinishedOnboardingBoolKey];
+}
+
+#pragma mark -
+
+- (NSString *)privacyPolicyLastUpdateTime {
+    return @"2018-05-15T19:39:57+00:00";
+}
+
+- (NSString *_Nullable)lastAcceptedPrivacyPolicy {
+    NSString *_Nullable unixTime = [NSUserDefaults.standardUserDefaults
+      stringForKey:PrivacyPolicyAcceptedStringTimeKey];
 
     return unixTime;
 }
 
-- (void)setAcceptedPrivacyPolicyUnixTime:(NSNumber *)privacyPolicyUnixTime {
-    [NSUserDefaults.standardUserDefaults setObject:privacyPolicyUnixTime
-                                            forKey:PrivacyPolicyAcceptedRFC3339StringKey];
+- (BOOL)hasAcceptedLatestPrivacyPolicy {
+    NSString *_Nullable lastAccepted = [self lastAcceptedPrivacyPolicy];
+    return [[self privacyPolicyLastUpdateTime] isEqualToString:lastAccepted];
 }
+
+- (void)setAcceptedPrivacyPolicy:(NSString *)privacyPolicyTimestamp {
+    [NSUserDefaults.standardUserDefaults setObject:privacyPolicyTimestamp
+                                            forKey:PrivacyPolicyAcceptedStringTimeKey];
+}
+
+- (void)setAcceptedLatestPrivacyPolicy {
+    [NSUserDefaults.standardUserDefaults setObject:[self privacyPolicyLastUpdateTime]
+                                            forKey:PrivacyPolicyAcceptedStringTimeKey];
+}
+
+#pragma mark -
 
 - (void)setEmbeddedEgressRegions:(NSArray<NSString *> *_Nullable)regions {
     [NSUserDefaults.standardUserDefaults setObject:regions

--- a/Psiphon/ViewControllers/OnboardingViewController.m
+++ b/Psiphon/ViewControllers/OnboardingViewController.m
@@ -232,6 +232,8 @@ const int NumPages = 4;
         [self setCurrentOnboardingPage:newPage];
     } else {
         if (self.delegate) {
+            ContainerDB *containerDB = [[ContainerDB alloc] init];
+            [containerDB setHasFinishedOnboarding];
             [self.delegate onboardingFinished:self];
         }
         return;
@@ -296,7 +298,7 @@ const int NumPages = 4;
 - (void)onPrivacyPolicyAccepted {
     // Stores the privacy policy date that the user accepted.
     ContainerDB *containerDB = [[ContainerDB alloc] init];
-    [containerDB setAcceptedPrivacyPolicyUnixTime:[containerDB privacyPolicyLastUpdateTime]];
+    [containerDB setAcceptedLatestPrivacyPolicy];
     // Go to next page;
     [self gotoNextPage];
 }

--- a/Psiphon/ViewControllers/RootContainerController.m
+++ b/Psiphon/ViewControllers/RootContainerController.m
@@ -75,13 +75,9 @@
     [super viewDidLoad];
     [self.view setBackgroundColor:[UIColor blackColor]];
 
-    // If has accepted the latest privacy policy and vpn configuration has been installed,
-    // then show this
     ContainerDB *containerDB = [[ContainerDB alloc] init];
-    NSNumber *_Nullable lastAcceptedPrivacyUnixTime = [containerDB lastAcceptedPrivacyPolicy];
 
-    if (!lastAcceptedPrivacyUnixTime ||
-        ([lastAcceptedPrivacyUnixTime compare:[containerDB privacyPolicyLastUpdateTime]] == NSOrderedAscending)) {
+    if (![containerDB hasFinishedOnboarding]) {
         [self switchToOnboarding];
     } else {
         [self switchToMainScreenAndStartVPN:FALSE];

--- a/Shared/PsiFeedbackLogger.h
+++ b/Shared/PsiFeedbackLogger.h
@@ -60,6 +60,8 @@ typedef NSString * PsiFeedbackLogType;
 
 + (NSDictionary *_Nonnull)unpackError:(NSError *_Nullable)error;
 
++ (id _Nonnull)safeValue:(id _Nullable)value;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Shared/PsiFeedbackLogger.m
+++ b/Shared/PsiFeedbackLogger.m
@@ -498,4 +498,8 @@ PsiFeedbackLogType const FeedbackInternalLogType = @"FeedbackLoggerInternal";
 
 }
 
++ (id _Nonnull)safeValue:(id _Nullable)value {
+    return value ? value : NSNull.null;
+}
+
 @end


### PR DESCRIPTION
- We still see asserts fail in production when comapring the same static NSNumber value to itself, after being saved with NSUserDefaults.

  To resolve this, we seperated the "onboarding finished" flag from the "privacy-policy accepted date" value.

  "privacy-policy accepted date" will just be stored as a string, and never parsed since we only need to test it for strict equality with the latest privacy-policy date.