### PR TITLE
Add loading state to rewarded video button

### DIFF
--- a/Psiphon.xcodeproj/project.pbxproj
+++ b/Psiphon.xcodeproj/project.pbxproj
@@ -113,6 +113,7 @@
 		9BFECFE618966005B01CF582 /* MoPubRewardedAdControllerWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 9BFEC970B3CC179C3B9DE44D /* MoPubRewardedAdControllerWrapper.m */; };
 		9BFECFEB3BC9F10542C1A416 /* PsiphonConfigUserDefaults.m in Sources */ = {isa = PBXBuildFile; fileRef = 9BFEC584519C408D9D6D3FF1 /* PsiphonConfigUserDefaults.m */; };
 		A8408008B18277F93286799F /* PsiphonProgressView.m in Sources */ = {isa = PBXBuildFile; fileRef = A84087FA4B1BC2C725D900D9 /* PsiphonProgressView.m */; };
+		A840803A0733D9FCA5410796 /* ActivityIndicatorRoyalSkyButton.m in Sources */ = {isa = PBXBuildFile; fileRef = A840842CECC0146241243488 /* ActivityIndicatorRoyalSkyButton.m */; };
 		A84080838645BD1023136C3B /* PsiCashPurchaseView.m in Sources */ = {isa = PBXBuildFile; fileRef = A8408183BCB31ED8F0855E90 /* PsiCashPurchaseView.m */; };
 		A84080E163F24876A1476544 /* VPNStartAndStopButton.m in Sources */ = {isa = PBXBuildFile; fileRef = A8408F6123BCC98725932A59 /* VPNStartAndStopButton.m */; };
 		A84080E9FC63E29F71A79A63 /* RelaySubject.m in Sources */ = {isa = PBXBuildFile; fileRef = A84086DF1DDA5CC90C437009 /* RelaySubject.m */; };
@@ -487,6 +488,7 @@
 		A84083B0CB962827E7C93024 /* PsiCashPurchaseAlertView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PsiCashPurchaseAlertView.m; sourceTree = "<group>"; };
 		A84083F358BD2CC1440107B8 /* PsiCashSpeedBoostMeterView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PsiCashSpeedBoostMeterView.m; sourceTree = "<group>"; };
 		A840841151FC43C5E1658677 /* AlertDialogs.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AlertDialogs.m; sourceTree = "<group>"; };
+		A840842CECC0146241243488 /* ActivityIndicatorRoyalSkyButton.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ActivityIndicatorRoyalSkyButton.m; sourceTree = "<group>"; };
 		A8408454F205262BF90B55C1 /* UIImageView+Additions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIImageView+Additions.h"; sourceTree = "<group>"; };
 		A840845849B24AAA0E714664 /* LoadingCircleLayer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LoadingCircleLayer.m; sourceTree = "<group>"; };
 		A84084C5C538AC8171021D2C /* UIView+Additions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIView+Additions.m"; sourceTree = "<group>"; };
@@ -532,6 +534,7 @@
 		A8408C8A7CA3C009F01FDA3B /* SkyRegionSelectionViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SkyRegionSelectionViewController.m; sourceTree = "<group>"; };
 		A8408CEB0E34BC897F3FA7D6 /* OnboardingScrollableView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OnboardingScrollableView.m; sourceTree = "<group>"; };
 		A8408D462EEE90AA7F2A8AFA /* SwoopView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SwoopView.h; sourceTree = "<group>"; };
+		A8408D7A1D96FE89B4FB49C1 /* ActivityIndicatorRoyalSkyButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ActivityIndicatorRoyalSkyButton.h; sourceTree = "<group>"; };
 		A8408D96EC06ED36F86C690D /* OnboardingViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OnboardingViewController.m; sourceTree = "<group>"; };
 		A8408DA63B0B641B765A1E4D /* PsiCashView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PsiCashView.m; sourceTree = "<group>"; };
 		A8408DB71B7BE2CF13F9CD04 /* UIView+Additions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIView+Additions.h"; sourceTree = "<group>"; };
@@ -1011,6 +1014,8 @@
 				A8408902709B9D562B559532 /* CloudsView.h */,
 				A840886E2E6D8EA82B0EC427 /* UIImageView+Additions.m */,
 				A8408454F205262BF90B55C1 /* UIImageView+Additions.h */,
+				A840842CECC0146241243488 /* ActivityIndicatorRoyalSkyButton.m */,
+				A8408D7A1D96FE89B4FB49C1 /* ActivityIndicatorRoyalSkyButton.h */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -1722,6 +1727,7 @@
 				A84081194DA12328ABB5A43E /* UIImageView+Additions.m in Sources */,
 				A840849074861D633B3EB4D1 /* AppEvent.m in Sources */,
 				A84080E9FC63E29F71A79A63 /* RelaySubject.m in Sources */,
+				A840803A0733D9FCA5410796 /* ActivityIndicatorRoyalSkyButton.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Psiphon/Ad/AdControllerWrapper.h
+++ b/Psiphon/Ad/AdControllerWrapper.h
@@ -81,6 +81,13 @@ static inline BOOL adBeingPresented(AdPresentation ap) {
     return (ap == AdPresentationWillAppear || ap == AdPresentationDidAppear || ap == AdPresentationWillDisappear);
 };
 
+typedef NS_ENUM(NSInteger, AdLoadStatus) {
+    AdLoadStatusNone = 1,
+    AdLoadStatusInProgress,
+    AdLoadStatusDone,
+    AdLoadStatusError
+};
+
 #pragma mark -
 
 FOUNDATION_EXPORT NSErrorDomain const AdControllerWrapperErrorDomain;
@@ -117,12 +124,11 @@ typedef NS_ERROR_ENUM(AdControllerWrapperErrorDomain, AdControllerWrapperErrorCo
 @property (nonatomic, readonly) AdControllerTag tag;
 
 /**
- * Hot relay subject. Emits @(TRUE) if ad is ready to be displayed, @(FALSE) otherwise.
- * The value is expected to change after the ad has started presenting.
- * To avoid unnecessary computation for observers of this property, implementations of this protocol
- * should check the current value before emitting new value.
+ * Hot relay subject. Emits items of type @(AdLoadedStatus).
+ *
+ * Default value is `AdLoadStatusNone`.
  */
-@property (nonatomic, readonly) BehaviorRelay<NSNumber *> *canPresent;
+@property (nonatomic, readonly) BehaviorRelay<NSNumber *> *adLoadStatus;
 
 /**
  * presentedAdDismissed is hot infinite signal - emits RACUnit whenever an ad is shown.

--- a/Psiphon/Ad/AdManager.h
+++ b/Psiphon/Ad/AdManager.h
@@ -47,22 +47,18 @@ FOUNDATION_EXPORT AdControllerTag const AdControllerTagMoPubTunneledRewardedVide
 @property (nonatomic, readonly) RACBehaviorSubject<NSNumber *> *adIsShowing;
 
 /**
- * Emits @(TRUE) when the untunneled interstitial is ready to be presented.
- * Emits @(FALSE) when app conditions are such that the ad cannot be presented, this is regardless of whether the
- * ad has been loaded.
- * Subject initially has default value @(FALSE).
+ * Hot relay - emits items of type @(AdLoadStatus).
+ * Subject has initial value of `AdLoadStatusNone`.
  * @scheduler Events are delivered on the main thread.
  */
-@property (nonatomic, readonly) RACBehaviorSubject<NSNumber *> *untunneledInterstitialCanPresent;
+@property (nonatomic, readonly) RACBehaviorSubject<NSNumber *> *untunneledInterstitialLoadStatus;
 
 /**
- * Emits @(TRUE) when tunneled or untunneled rewarded video is ready to be presented.
- * Emits @(FALSE) when app conditions are such that the ad cannot be presented, this is regardless of whether the
- * ad has been loaded.
- * Subject initially has default value @(FALSE).
+ * Hot relay - emits items of type @(AdLoadStatus).
+ * Subject has initial value of `AdLoadStatusNone`.
  * @scheduler Events are delivered on the main thread.
  */
-@property (nonatomic, readonly) RACBehaviorSubject<NSNumber *> *rewardedVideoCanPresent;
+@property (nonatomic, readonly) RACBehaviorSubject<NSNumber *> *rewardedVideoLoadStatus;
 
 + (instancetype)sharedInstance;
 
@@ -71,6 +67,11 @@ FOUNDATION_EXPORT AdControllerTag const AdControllerTagMoPubTunneledRewardedVide
  * This should be called during the apps difFinishLaunchingWithOptions: delegate callback.
  */
 - (void)initializeAdManager;
+
+/**
+ * Initializes observables that handle loading of rewarded videos.
+ */
+- (void)initializeRewardedVideos;
 
 /**
  * Reset user consent for all networks.

--- a/Psiphon/ViewControllers/Views/ActivityIndicatorRoyalSkyButton.h
+++ b/Psiphon/ViewControllers/Views/ActivityIndicatorRoyalSkyButton.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2019, Psiphon Inc.
+ * All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#import "RoyalSkyButton.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ActivityIndicatorRoyalSkyButton : RoyalSkyButton
+
+- (void)setTitleForIndicatorAnimating:(NSString *)title;
+
+- (void)startAnimating;
+
+- (void)stopAnimating;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Psiphon/ViewControllers/Views/ActivityIndicatorRoyalSkyButton.m
+++ b/Psiphon/ViewControllers/Views/ActivityIndicatorRoyalSkyButton.m
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2019, Psiphon Inc.
+ * All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#import "ActivityIndicatorRoyalSkyButton.h"
+
+
+@implementation ActivityIndicatorRoyalSkyButton {
+    UIActivityIndicatorView *activityIndicator;
+    NSString *titleIndicatorAnimating;
+}
+
+- (instancetype)initWithFrame:(CGRect)frame {
+    self = [super initWithFrame:CGRectZero];
+    if (self) {
+        activityIndicator = [[UIActivityIndicatorView alloc]
+          initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleWhite];
+    }
+    return self;
+}
+
+- (void)setTitleForIndicatorAnimating:(NSString *)title {
+    titleIndicatorAnimating = title;
+}
+
+- (void)startAnimating {
+    if (!activityIndicator.animating) {
+        [activityIndicator startAnimating];
+        [self updateTitle];
+    }
+}
+
+- (void)stopAnimating {
+    if (activityIndicator.animating) {
+        [activityIndicator stopAnimating];
+        [self updateTitle];
+    }
+}
+
+#pragma mark -
+
+- (NSString *)currentTitle {
+    if (activityIndicator.animating) {
+        return titleIndicatorAnimating;
+    } else {
+        return [super currentTitle];
+    }
+}
+
+#pragma mark - AutoLayoutProtocol init
+
+ - (void)autoLayoutAddSubviews {
+    [super autoLayoutAddSubviews];
+    [self addSubview:activityIndicator];
+}
+
+- (void)autoLayoutSetupSubviewsLayoutConstraints {
+    [super autoLayoutSetupSubviewsLayoutConstraints];
+
+    activityIndicator.translatesAutoresizingMaskIntoConstraints = FALSE;
+    [NSLayoutConstraint activateConstraints:@[
+      [activityIndicator.topAnchor constraintLessThanOrEqualToAnchor:self.topAnchor],
+      [activityIndicator.bottomAnchor constraintGreaterThanOrEqualToAnchor:self.bottomAnchor],
+      [activityIndicator.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
+      [activityIndicator.trailingAnchor constraintEqualToAnchor:self.trailingAnchor
+                                                       constant:-10.f]
+    ]];
+}
+
+
+@end

--- a/Psiphon/ViewControllers/Views/PsiCash/PsiCashView.h
+++ b/Psiphon/ViewControllers/Views/PsiCash/PsiCashView.h
@@ -21,7 +21,8 @@
 #import "PsiCashBalanceView.h"
 #import "PsiCashClientModel.h"
 #import "PsiCashSpeedBoostMeterView.h"
-#import "RoyalSkyButton.h"
+#import "ActivityIndicatorRoyalSkyButton.h"
+
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -29,8 +30,15 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly) PsiCashBalanceView *balance;
 @property (nonatomic, readonly) PsiCashSpeedBoostMeterView *meter;
-@property (nonatomic, readonly) RoyalSkyButton *rewardedVideoButton;
+@property (nonatomic, readonly) ActivityIndicatorRoyalSkyButton *rewardedVideoButton;
 @property (nonatomic, assign) BOOL hideRewardedVideoButton;
+
+/**
+ * Should be set to TRUE by the target object of rewarded video button if it is the first
+ * time the button is being tapped.
+ * Default value is FALSE.
+ */
+@property (nonatomic, readwrite) BOOL rewardedVideoButtonTappedOnce;
 
 + (void)animateBalanceChangeOf:(NSNumber*)delta
                withPsiCashView:(PsiCashView*)psiCashView

--- a/Psiphon/ViewControllers/Views/PsiCash/PsiCashView.m
+++ b/Psiphon/ViewControllers/Views/PsiCash/PsiCashView.m
@@ -24,6 +24,7 @@
 #import "UIFont+Additions.h"
 #import "UIView+AutoLayoutViewGroup.h"
 #import "RoyalSkyButton.h"
+#import "Strings.h"
 
 @interface PsiCashView ()
 @property (atomic, readwrite) PsiCashClientModel *model;
@@ -37,6 +38,14 @@
     UIView *rewardedVideoButtonContainer;
     UIView *topBorderBlocker;
     UIView *bottomBorderBlocker;
+}
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        _rewardedVideoButtonTappedOnce = FALSE;
+    }
+    return self;
 }
 
 + (NSString *)videoReadyTitleText {
@@ -86,12 +95,16 @@
     rewardedVideoButtonContainer = [[UIView alloc] init];
 
     // Setup rewarded video button
-    _rewardedVideoButton = [[RoyalSkyButton alloc] initForAutoLayout];
+    _rewardedVideoButton = [[ActivityIndicatorRoyalSkyButton alloc] initForAutoLayout];
     [_rewardedVideoButton setTitle:[PsiCashView videoReadyTitleText]
                           forState:UIControlStateNormal];
     [_rewardedVideoButton setTitle:[PsiCashView videoUnavailableTitleText]
                           forState:UIControlStateDisabled];
-    _rewardedVideoButton.enabled = FALSE;
+    [_rewardedVideoButton setTitleForIndicatorAnimating:[Strings psiCashRewardedVideoButtonLoadingTitle]];
+
+    _rewardedVideoButton.enabled = TRUE;  // Enable button click regardless of rewarded video load state.
+    _rewardedVideoButton.userInteractionEnabled = TRUE;
+
     _rewardedVideoButton.backgroundColor = UIColor.clearColor;
 
     topBorderBlocker = [[UIView alloc] init];

--- a/Psiphon/ViewControllers/Views/RoyalSkyButton.m
+++ b/Psiphon/ViewControllers/Views/RoyalSkyButton.m
@@ -27,17 +27,20 @@
     LayerAutoResizeUIView *statusGradientView;
 }
 
-- (void)setEnabled:(BOOL)enabled {
-    [super setEnabled:enabled];
-    self.titleLabel.attributedText = [RoyalSkyButton styleLabelText:self.currentTitle];
+- (void)setBackgroundGradient:(BOOL)enableGradient {
 
-    if (enabled) {
+    if (enableGradient) {
         statusGradientLayer.colors = @[(id)UIColor.lightRoyalBlueTwo.CGColor,
                                        (id)UIColor.lightishBlue.CGColor];
     } else {
         statusGradientLayer.colors = @[(id)UIColor.regentGrey.CGColor,
                                        (id)UIColor.regentGrey.CGColor];
     }
+}
+
+- (void)setEnabled:(BOOL)enabled {
+    [super setEnabled:enabled];
+    [self setBackgroundGradient:enabled];
 }
 
 #pragma mark - AutoLayoutViewGroup

--- a/Psiphon/ViewControllers/Views/SkyButton.h
+++ b/Psiphon/ViewControllers/Views/SkyButton.h
@@ -43,6 +43,18 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)setTitle:(NSString *)title forState:(UIControlState)controlState;
 
+/**
+ * Subclasses can override this method to customize the title style.
+ */
+- (NSAttributedString *_Nullable)styleTitleText:(NSString *)title;
+
+/**
+ * Updates title to reflect current view state.
+ *
+ * Subclasses should override `-currentTitle` and call this method to update title.
+ */
+- (void)updateTitle;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Psiphon/ViewControllers/Views/SkyButton.m
+++ b/Psiphon/ViewControllers/Views/SkyButton.m
@@ -66,13 +66,13 @@
 
 - (void)setEnabled:(BOOL)enabled {
     [super setEnabled:enabled];
-    _titleLabel.text = self.currentTitle;
+    [self updateTitle];
 }
 
 - (void)setTitle:(NSString *)title {
     normalTitle = title;
     disabledTitle = title;
-    _titleLabel.text = title;
+    [self updateTitle];
 }
 
 - (void)setTitle:(NSString *)title forState:(UIControlState)controlState {
@@ -89,6 +89,14 @@
     } else {
         return disabledTitle;
     }
+}
+
+- (NSAttributedString *_Nullable)styleTitleText:(NSString *)title {
+   return [[NSAttributedString alloc] initWithString:title];
+}
+
+- (void)updateTitle {
+    _titleLabel.attributedText = [self styleTitleText:[self currentTitle]];
 }
 
 #pragma mark - AutoLayoutProtocol

--- a/Shared/Strings.h
+++ b/Shared/Strings.h
@@ -89,6 +89,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (NSString *)psiCashSpeedBoostMeterUserNotOnboardedTitle;
 
++ (NSString *)psiCashRewardedVideoButtonLoadingTitle;
+
 #pragma mark - VPN
 
 + (NSString *)vpnPermissionDeniedAlertMessage;

--- a/Shared/Strings.m
+++ b/Shared/Strings.m
@@ -134,6 +134,10 @@
     return NSLocalizedStringWithDefaultValue(@"PSICASH_SPEED_BOOST_USER_NOT_ONBOARDED_TEXT", nil, [NSBundle mainBundle], @"Learn about PsiCash", @"Text which appears in the Speed Boost meter when the user has not gone through the PsiCash onboarding. Please keep this text concise as the width of the text box is restricted in size. 'PsiCash' should not be translated or transliterated.");
 }
 
++ (NSString *)psiCashRewardedVideoButtonLoadingTitle {
+    return  NSLocalizedStringWithDefaultValue(@"PSICASH_REWARDED_VIDEO_LOADING_TITLE", nil, [NSBundle mainBundle], @"Loading", @"Button title when loading.");
+}
+
 + (NSString *)vpnPermissionDeniedAlertMessage {
     return NSLocalizedStringWithDefaultValue(@"VPN_START_PERMISSION_DENIED_MESSAGE", nil, [NSBundle mainBundle], @"Psiphon needs your permission to install a VPN profile in order to connect.\n\nPsiphon is committed to protecting the privacy of our users. You can review our privacy policy by tapping \"Privacy Policy\".", @"('Privacy Policy' should be the same translation as privacy policy button VPN_START_PRIVACY_POLICY_BUTTON), (Do not translate 'VPN profile'), (Do not translate 'Psiphon')");
 }

--- a/Shared/Strings/en.lproj/Localizable.strings
+++ b/Shared/Strings/en.lproj/Localizable.strings
@@ -224,6 +224,9 @@
 /* Title text on the third PsiCash onboarding screen. 'Speed Boost' is a reward that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */
 "PSICASH_ONBOARDING_PAGE_3_TITLE" = "Speed Boost";
 
+/* Button title when loading. */
+"PSICASH_REWARDED_VIDEO_LOADING_TITLE" = "Loading";
+
 /* Text which appears in the Speed Boost meter when the user has activated Speed Boost. Please keep this text concise as the width of the text box is restricted in size. 'Speed Boost' is a reward that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */
 "PSICASH_SPEED_BOOST_ACTIVE_TEXT" = "Speed Boost Active";
 


### PR DESCRIPTION
- Rewarded video button starts with an initial state of "loaded".

- `canPresent` signal of `AdControllerWrapperProtocol` is enriched with more state information.