### PR TITLE
Change DisableTimeouts functionality

### DIFF
--- a/PsiphonTunnel.framework/build-git-commit.txt
+++ b/PsiphonTunnel.framework/build-git-commit.txt
@@ -1,1 +1,1 @@
-a78feadfcfbadbd37d12a4db753d15e2ec7c1eb4
+4856da6cacc61bbd1626aafe593d743f99d4cacf

--- a/Shared/PsiphonConfigUserDefaults.m
+++ b/Shared/PsiphonConfigUserDefaults.m
@@ -68,7 +68,7 @@
     }
 
     if ([userDefaults boolForKey:kDisableTimeouts]) {
-        [userConfigs setObject:@(3.0) forKey:@"NetworkLatencyMultiplier"];
+        [userConfigs setObject:@(0.1) forKey:@"NetworkLatencyMultiplierLambda"];
     }
 
     NSString *upstreamProxyUrl = [userDefaults stringForKey:PSIPHON_CONFIG_UPSTREAM_PROXY_URL];


### PR DESCRIPTION
Instead of setting a long, fixed latency multiplier, DisableTimeouts now just
sets the random distribution to approximately uniformly select from the
default (or tactics configured) latency multiplier range.

The intent of this change is to avoid unnecessarily long timeouts that
resulted from users incorrectly checking this option, while still often trying
longer timeouts in case they are needed.