### PR TITLE
Fix debug function not protected by DEBUG flag

### DIFF
--- a/Psiphon/ViewControllers/MainViewController.m
+++ b/Psiphon/ViewControllers/MainViewController.m
@@ -953,6 +953,7 @@ NSString * const CommandStopVPN = @"StopVPN";
 
 }
 
+#if DEBUG
 - (void)setupVersionLabel {
     versionLabel.translatesAutoresizingMaskIntoConstraints = NO;
     [versionLabel setTitle:[NSString stringWithFormat:@"v%@",[[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"]]
@@ -974,6 +975,7 @@ NSString * const CommandStopVPN = @"StopVPN";
       [versionLabel.topAnchor constraintEqualToAnchor:psiCashWidget.bottomAnchor constant:10.f]
     ]];
 }
+#endif
 
 - (void)setupSubscriptionsBar {
     [subscriptionsBar addTarget:self


### PR DESCRIPTION
Motivation:
Without the DEBUG flag, this code will try
to be compiled in a release build.

Modifications:
Wrapped `setupVersionLabel` function in DEBUG flag.

Result:
Fixes release build compilation error