### PR TITLE
Fix redundant subscription server requests

### DIFF
--- a/PsiphonVPN/IAP/MutableSubscriptionData.h
+++ b/PsiphonVPN/IAP/MutableSubscriptionData.h
@@ -45,7 +45,8 @@ NS_ASSUME_NONNULL_BEGIN
  * Returns TRUE if Subscription info is missing, the App Store receipt has changed, or we expect
  * the subscription to be renewed.
  * If this method returns TRUE, current subscription information should be deemed stale, and
- * subscription verifier server should be contacted to get latest subscription information.
+ * subscription verifier server should be contacted to get latest subscription information -- unless
+ * the client already has an active authorization.
  *
  * @note This is a blocking function until the new state is persisted.
  *

--- a/PsiphonVPN/IAP/MutableSubscriptionData.m
+++ b/PsiphonVPN/IAP/MutableSubscriptionData.m
@@ -85,7 +85,7 @@ PsiFeedbackLogType const MutableSubscriptionDataLogType = @"SubscriptionData";
 
     // Last expiry date recorded by the container still has time left - YES
     NSDate *_Nullable containerReceiptExpiry = [sharedDB getContainerLastSubscriptionReceiptExpiryDate];
-    if (![self hasActiveAuthorizationForNow] && containerReceiptExpiry && [containerReceiptExpiry afterOrEqualTo:[NSDate date]]) {
+    if (containerReceiptExpiry && [containerReceiptExpiry afterOrEqualTo:[NSDate date]]) {
         ShouldUpdateAuthResult *result = [ShouldUpdateAuthResult shouldUpdateAuth:YES reason:@"containerHasReceiptWithExpiry"];
         [PsiFeedbackLogger infoWithType:MutableSubscriptionDataLogType
                                    json:@{@"event": @"shouldUpdateAuth",

--- a/PsiphonVPN/IAP/MutableSubscriptionData.m
+++ b/PsiphonVPN/IAP/MutableSubscriptionData.m
@@ -85,7 +85,7 @@ PsiFeedbackLogType const MutableSubscriptionDataLogType = @"SubscriptionData";
 
     // Last expiry date recorded by the container still has time left - YES
     NSDate *_Nullable containerReceiptExpiry = [sharedDB getContainerLastSubscriptionReceiptExpiryDate];
-    if (containerReceiptExpiry && [containerReceiptExpiry afterOrEqualTo:[NSDate date]]) {
+    if (![self hasActiveAuthorizationForNow] && containerReceiptExpiry && [containerReceiptExpiry afterOrEqualTo:[NSDate date]]) {
         ShouldUpdateAuthResult *result = [ShouldUpdateAuthResult shouldUpdateAuth:YES reason:@"containerHasReceiptWithExpiry"];
         [PsiFeedbackLogger infoWithType:MutableSubscriptionDataLogType
                                    json:@{@"event": @"shouldUpdateAuth",

--- a/PsiphonVPN/IAP/SubscriptionVerifierService.h
+++ b/PsiphonVPN/IAP/SubscriptionVerifierService.h
@@ -110,7 +110,7 @@ typedef NS_ERROR_ENUM(ReceiptValidationErrorDomain, PsiphonReceiptValidationErro
 typedef NS_ENUM(NSInteger, SubscriptionCheckEnum) {
     SubscriptionCheckShouldUpdateAuthorization,
     SubscriptionCheckHasActiveAuthorization,
-    SubscriptionCheckAuthorizationExpired,
+    SubscriptionCheckAuthorizationExpired
 };
 
 

--- a/PsiphonVPN/IAP/SubscriptionVerifierService.m
+++ b/PsiphonVPN/IAP/SubscriptionVerifierService.m
@@ -58,7 +58,7 @@ PsiFeedbackLogType const SubscriptionVerifierServiceLogType = @"SubscriptionVeri
         } else {
             // subscription server doesn't need to be contacted.
             // Checks if subscription is active compared to device's clock.
-            if ([subscription hasActiveAuthorizationForDate:[NSDate date]]) {
+            if ([subscription hasActiveAuthorizationForNow]) {
                 [subscriber sendNext:[LocalSubscriptionCheckResult localSubscriptionCheckResult:@(SubscriptionCheckHasActiveAuthorization)
                                                                                          reason:shouldUpdateAuthResult.reason]];
                 [subscriber sendCompleted];

--- a/Shared/SubscriptionData.h
+++ b/Shared/SubscriptionData.h
@@ -68,9 +68,15 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)hasActiveSubscriptionForNow;
 
 /**
+* Returns TRUE if subscription authorization is active against current time.
+* @return TRUE if authorization is active, FALSE otherwise.
+*/
+- (BOOL)hasActiveAuthorizationForNow;
+
+/**
  * Returns TRUE if subscription authorization is active compared to provided date.
  * @param date Date to compare the authorization expiration to.
- * @return TRUE if subscription is active, FALSE otherwise.
+ * @return TRUE if authorization is active, FALSE otherwise.
  */
 - (BOOL)hasActiveAuthorizationForDate:(NSDate *)date;
 

--- a/Shared/SubscriptionData.m
+++ b/Shared/SubscriptionData.m
@@ -61,6 +61,10 @@
     return [self hasActiveAuthorizationForDate:[NSDate date]];
 }
 
+- (BOOL)hasActiveAuthorizationForNow {
+    return [self hasActiveAuthorizationForDate:[NSDate date]];
+}
+
 - (BOOL)hasActiveAuthorizationForDate:(NSDate *)date {
     if ([self isEmpty]) {
         return FALSE;


### PR DESCRIPTION
Fixes the scenario where a client with a valid/active subscription authorization may erroneously request a new one from the verification server.