### PR TITLE
Fix erroneous extension alert to open container to start

### DIFF
--- a/Psiphon/VPNState.swift
+++ b/Psiphon/VPNState.swift
@@ -115,7 +115,7 @@ extension TunnelStartStopIntent {
     
     var integerCode: Int {
         switch self {
-        case .start(transition: .restart): return Int(TUNNEL_INTENT_UNDEFINED)
+        case .start(transition: .some(_)): return Int(TUNNEL_INTENT_UNDEFINED)
         case .start(transition: .none): return Int(TUNNEL_INTENT_START)
         case .stop: return Int(TUNNEL_INTENT_STOP)
         }

--- a/Psiphon/VPNState.swift
+++ b/Psiphon/VPNState.swift
@@ -113,6 +113,14 @@ enum TunnelStartStopIntent: Equatable {
 
 extension TunnelStartStopIntent {
     
+    var integerCode: Int {
+        switch self {
+        case .start(transition: .restart): return Int(TUNNEL_INTENT_UNDEFINED)
+        case .start(transition: .none): return Int(TUNNEL_INTENT_START)
+        case .stop: return Int(TUNNEL_INTENT_STOP)
+        }
+    }
+    
     static func initializeIntentGiven(
         _ reason: TunnelProviderSyncReason, _ syncedState: TunnelProviderSyncedState
     ) -> Self? {
@@ -129,7 +137,7 @@ extension TunnelStartStopIntent {
         case .inactive:
             return .stop
         case .unknown(_):
-            return nil
+            return .none
         }
     }
     
@@ -334,13 +342,20 @@ fileprivate func vpnProviderManagerStateReducer<T: TunnelProviderManager>(
     case .vpnStatusChanged(let vpnStatus):
         state.providerVPNStatus = vpnStatus
         
+        var effects = [Effect<VPNProviderManagerStateAction<T>>]()
+        
         // Resets tunnelIntent transition flag if previously was `.restart`.
         // Discussion:
         // The flag is reset at the disconnecting state change, since this is a clear
         // signal that the provider has started transitioning (being stopped and started again).
         //
         if case .disconnecting = vpnStatus, case .start(transition: .restart) = state.tunnelIntent {
-            state.tunnelIntent = .start(transition: .none)
+            effects.append(
+                state.tunnelIntent.updateState(
+                    newValue: .start(transition: .none),
+                    sharedDB: environment.sharedDB
+                ).mapNever()
+            )
         }
         
         // Sends startPsiphonTunnel message if tunnelIntent is start, and
@@ -502,8 +517,15 @@ fileprivate func vpnProviderManagerStateReducer<T: TunnelProviderManager>(
             switch intent {
             case .start(transition: .none):
                 // Starts Psiphon tunnel.
-                state.tunnelIntent = .start(transition: .none)
-                return [ Effect(value: .startPsiphonTunnel) ]
+                let intentUpdateEffect = state.tunnelIntent.updateState(
+                    newValue: .start(transition: .none),
+                    sharedDB: environment.sharedDB
+                )
+                
+                return [
+                    intentUpdateEffect.mapNever(),
+                    Effect(value: .startPsiphonTunnel)
+                ]
                 
             case .start(transition: .restart):
                 // Restarts tunnel provider if not stopped.
@@ -511,13 +533,28 @@ fileprivate func vpnProviderManagerStateReducer<T: TunnelProviderManager>(
                     tpm.connectionStatus.providerNotStopped else {
                         return []
                 }
-                state.tunnelIntent = .start(transition: .restart)
-                return [ Effect(value: .stopVPN) ]
+                
+                let intentUpdateEffect = state.tunnelIntent.updateState(
+                    newValue: .start(transition: .restart),
+                    sharedDB: environment.sharedDB
+                )
+                
+                return [
+                    intentUpdateEffect.mapNever(),
+                    Effect(value: .stopVPN)
+                ]
                 
             case .stop:
                 // Stops tunnel provider.
-                state.tunnelIntent = .stop
-                return [ Effect(value: .stopVPN) ]
+
+                let intentUpdateEffect = state.tunnelIntent.updateState(
+                    newValue: .stop,
+                    sharedDB: environment.sharedDB
+                )
+                return [
+                    intentUpdateEffect.mapNever(),
+                    Effect(value: .stopVPN)
+                ]
             }
         }
     }
@@ -554,21 +591,35 @@ fileprivate func tunnelProviderReducer<T: TunnelProviderManager>(
             state.providerSyncResult = .completed(.none)
         }
         
+        // This set of effects should be always be returned first
+        // before any other effects. This preserves the ordering of effects.
+        var firstEffects = [Effect<VPNProviderManagerStateAction<T>>]()
+        
         // Initialize tunnel intent value given none was previously set.
         switch (reason: reason, currentIntent:state.tunnelIntent, syncedState: syncedState) {
         case (reason: .appLaunched, currentIntent: .none, syncedState: _):
             // Initializes tunnel intent when app is first launched
-            state.tunnelIntent = .initializeIntentGiven(reason, syncedState)
+            firstEffects.append(
+                state.tunnelIntent.updateState(
+                    newValue: .initializeIntentGiven(reason, syncedState),
+                    sharedDB: environment.sharedDB
+                ).mapNever()
+            )
         case (reason: _, currentIntent: .stop, syncedState: .active(_)):
             // Updates the tunnel intent to `.start` if the tunnel provider was
             // started from system settings.
-            state.tunnelIntent = .start(transition: .none)
+            firstEffects.append(
+                state.tunnelIntent.updateState(
+                    newValue: .start(transition: .none),
+                    sharedDB: environment.sharedDB
+                ).mapNever()
+            )
         default: break
         }
         
         switch syncedState {
         case .zombie:
-            return [
+            return firstEffects + [
                 Effect(value: .stopVPN),
                 feedbackLog(.info, tag: vpnProviderSyncTag, "zombie provider").mapNever()
             ]
@@ -580,7 +631,7 @@ fileprivate func tunnelProviderReducer<T: TunnelProviderManager>(
             guard tpm.verifyConfig(forExpectedType: .startVPN) else {
                 // Failed to verify VPN config values.
                 // To update the config, tunnel is restarted.
-                return [
+                return firstEffects + [
                     Effect(value: .external(.tunnelStateIntent(.start(transition: .restart))))
                 ]
             }
@@ -589,13 +640,13 @@ fileprivate func tunnelProviderReducer<T: TunnelProviderManager>(
             // if vpnStartCondition passes.
             guard state.loadState.connectionStatus == .connecting,
                 environment.vpnStartCondition() else {
-                    return []
+                    return firstEffects
             }
-            return [ notifyStartVPN().mapNever() ]
+            return firstEffects + [ notifyStartVPN().mapNever() ]
             
         case .unknown(let errorEvent):
-            var effects = [Effect<VPNProviderManagerStateAction<T>>]()
-            effects.append(
+            var unknownEffects = [Effect<VPNProviderManagerStateAction<T>>]()
+            unknownEffects.append(
                 feedbackLog(.info, tag: vpnProviderSyncTag, errorEvent).mapNever()
             )
             
@@ -606,13 +657,23 @@ fileprivate func tunnelProviderReducer<T: TunnelProviderManager>(
             if case let .loaded(tpm) = state.loadState.value {
                 switch tpm.connectionStatus {
                 case .reasserting, .connected:
-                    state.tunnelIntent = .start(transition: .none)
+                    firstEffects.append(
+                        state.tunnelIntent.updateState(
+                            newValue: .start(transition: .none),
+                            sharedDB: environment.sharedDB
+                        ).mapNever()
+                    )
                     // No start/stop action is necessary.
-                    return effects
+                    return firstEffects + unknownEffects
                     
                 case .connecting, .invalid, .disconnecting, .disconnected:
-                    state.tunnelIntent = .stop
-                    return [ Effect(value: .stopVPN) ] + effects
+                    firstEffects.append(
+                        state.tunnelIntent.updateState(
+                            newValue: .stop,
+                            sharedDB: environment.sharedDB
+                        ).mapNever()
+                    )
+                    return firstEffects + [ Effect(value: .stopVPN) ] + unknownEffects
 
                 @unknown default:
                     fatalErrorFeedbackLog("Unknown connection status '\(tpm.connectionStatus)'")
@@ -620,16 +681,21 @@ fileprivate func tunnelProviderReducer<T: TunnelProviderManager>(
             } else {
             
                 // Resets tunnel intent, and stops VPN (if active).
-                state.tunnelIntent = .none
+                firstEffects.append(
+                    state.tunnelIntent.updateState(
+                        newValue: .none,
+                        sharedDB: environment.sharedDB
+                    ).mapNever()
+                )
                 
-                return [ Effect(value: .stopVPN) ] + effects
+                return firstEffects + [ Effect(value: .stopVPN) ] + unknownEffects
             }
             
         case .active(.connecting):
-            return []
+            return firstEffects
             
         case .active(.networkNotReachable):
-            return []
+            return firstEffects
             
         case .inactive:
             // Fixes "inactive" sync result and vpn status mismatch.
@@ -637,18 +703,23 @@ fileprivate func tunnelProviderReducer<T: TunnelProviderManager>(
                 switch tpm.connectionStatus {
                 case .reasserting, .connecting, .connected:
                     // Tunnel provider is expected to be inactive!
-                    state.tunnelIntent = .stop
-                    return [ Effect(value: .stopVPN) ]
+                    firstEffects.append(
+                        state.tunnelIntent.updateState(
+                            newValue: .stop,
+                            sharedDB: environment.sharedDB
+                        ).mapNever()
+                    )
+                    return firstEffects + [ Effect(value: .stopVPN) ]
                     
                 case .invalid, .disconnecting, .disconnected:
-                    return []
+                    return firstEffects
 
                 @unknown default:
                     fatalErrorFeedbackLog("Unknown connection status '\(tpm.connectionStatus)'")
                 }
             }
             
-            return []
+            return firstEffects
         }
         
     case .startTunnelResult(let result):
@@ -663,9 +734,16 @@ fileprivate func tunnelProviderReducer<T: TunnelProviderManager>(
             state.startStopState = .completed(.failure(errorEvent))
             
             // Resets tunnel intent, since desired tunnel start state could not be achieved.
-            state.tunnelIntent = .none
+            let intentUpdateEffect = state.tunnelIntent.updateState(
+                newValue: .none,
+                sharedDB: environment.sharedDB
+            )
             
-            return [ feedbackLog(.error, tag: vpnStartTag, errorEvent).mapNever() ]
+            
+            return [
+                intentUpdateEffect.mapNever(),
+                feedbackLog(.error, tag: vpnStartTag, errorEvent).mapNever()
+            ]
         }
         
     case .stopTunnelResult(.unit):
@@ -789,6 +867,20 @@ fileprivate func wrapVPNObserverWithTPMResult<T: TunnelProviderManager, Failure>
 }
 
 // MARK: Effects
+
+fileprivate extension Optional where Wrapped == TunnelStartStopIntent {
+    
+    mutating func updateState(
+        newValue: TunnelStartStopIntent?, sharedDB: PsiphonDataSharedDB
+    ) -> Effect<Never> {
+        self = newValue
+        let statusCode = self?.integerCode ?? Int(TUNNEL_INTENT_UNDEFINED)
+        return .fireAndForget {
+            sharedDB.setContainerTunnelIntentStatus(statusCode)
+        }
+    }
+    
+}
 
 fileprivate func notifyStartVPN() -> Effect<Never> {
     .fireAndForget {

--- a/PsiphonVPN/NEBridge.h
+++ b/PsiphonVPN/NEBridge.h
@@ -27,3 +27,8 @@
 
 // Network Extension queries
 #define EXTENSION_QUERY_TUNNEL_PROVIDER_STATE @"queryTunnelProviderState"
+
+// Integer codes for `TunnelStartStopIntent`.
+#define TUNNEL_INTENT_UNDEFINED 0
+#define TUNNEL_INTENT_START 1
+#define TUNNEL_INTENT_STOP 2

--- a/PsiphonVPN/PacketTunnelProvider.m
+++ b/PsiphonVPN/PacketTunnelProvider.m
@@ -687,10 +687,13 @@ typedef NS_ENUM(NSInteger, TunnelProviderState) {
     } else if ([NotifierAppEnteredBackground isEqualToString:message]) {
 
         LOG_DEBUG(@"container entered background");
-
+        
+        // TunnelStartStopIntent integer codes are defined in VPNState.swift.
+        NSInteger tunnelIntent = [self.sharedDB getContainerTunnelIntentStatus];
+        
         // If the container StartVPN command has not been received from the container,
         // and the container goes to the background, then alert the user to open the app.
-        if (self.waitForContainerStartVPNCommand) {
+        if (self.waitForContainerStartVPNCommand && tunnelIntent == TUNNEL_INTENT_START) {
             [self displayMessage:NSLocalizedStringWithDefaultValue(@"OPEN_PSIPHON_APP", nil, [NSBundle mainBundle], @"Please open Psiphon app to finish connecting.", @"Alert message informing the user they should open the app to finish connecting to the VPN. DO NOT translate 'Psiphon'.")];
         }
 

--- a/Shared/PsiphonDataSharedDB.h
+++ b/Shared/PsiphonDataSharedDB.h
@@ -108,6 +108,18 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Container Data (Data originating in the container)
 
+/** Returns the last `TunnelStartStopIntent` written by the container.
+The integer values are defined in `NEBridge.h` with prefix `TUNNEL_INTENT_`.
+ */
+- (NSInteger)getContainerTunnelIntentStatus;
+
+#if !(TARGET_IS_EXTENSION)
+/** Sets the `TunnelStartStopIntent` status to be used by the tunnel provider.
+ Values should be one of the constants defined in `NEBrdige.h` starting with prefix `TUNNEL_INTENT_`.
+ */
+- (void)setContainerTunnelIntentStatus:(NSInteger)statusCode;
+#endif
+
 /**
  * Last date/time immediately before the extension was last started from the container.
  * Check where `setContainerTunnelStartTime:` is called to set the last tunnel start time.

--- a/Shared/PsiphonDataSharedDB.m
+++ b/Shared/PsiphonDataSharedDB.m
@@ -49,6 +49,7 @@ UserDefaultsKey const ContainerAuthorizationSetKey = @"authorizations_container_
 
 UserDefaultsKey const SubscriptionVerificationDictionaryKey = @"subscription_verification_dictionary_key";
 
+UserDefaultsKey const ContainerTunnelIntentStatusIntKey = @"container_tunnel_intent_status_key";
 
 /**
  * Key for boolean value that when TRUE indicates that the extension crashed before stop was called.
@@ -311,6 +312,16 @@ UserDefaultsKey const DebugPsiphonConnectionStateStringKey = @"PsiphonDataShared
 #endif
 
 #pragma mark - Container Data (Data originating in the container)
+
+- (NSInteger)getContainerTunnelIntentStatus {
+    return [sharedDefaults integerForKey:ContainerTunnelIntentStatusIntKey];
+}
+
+#if !(TARGET_IS_EXTENSION)
+- (void)setContainerTunnelIntentStatus:(NSInteger)statusCode {
+    [sharedDefaults setInteger:statusCode forKey:ContainerTunnelIntentStatusIntKey];
+}
+#endif
 
 - (NSDate *_Nullable)getContainerTunnelStartTime {
     NSString *_Nullable rfc3339Date = [sharedDefaults stringForKey:TunnelStartTimeStringKey];


### PR DESCRIPTION
Motivation:
If the VPN is being stopped before being fully connected, and the
VPN is stopped from the container and the container backgrounded, then
the extension displayed alert to open the container
to finish connecting.

Modifications:
- Persist `TunnelStartStopIntent` value in the shared DB.
- Extension checks `TunnelStartStopIntent` value when it receives
  container backgrounded notification.

Result:
Fixed erroneous alert from tunnel provider.