### PR TITLE
Updated tunnel provider failed IPC handling

### DIFF
--- a/Psiphon/FeedbackDescriptions.swift
+++ b/Psiphon/FeedbackDescriptions.swift
@@ -94,3 +94,7 @@ extension UserDefaultsConfig: CustomFieldFeedbackDescription {
     }
     
 }
+
+extension Optional: FeedbackDescription where Wrapped == TunnelStartStopIntent {}
+extension TunnelStartStopIntent: FeedbackDescription {}
+extension TunnelStartStopIntentReason: FeedbackDescription {}

--- a/Psiphon/SwiftDelegate.swift
+++ b/Psiphon/SwiftDelegate.swift
@@ -404,16 +404,22 @@ extension SwiftDelegate: SwiftBridgeDelegate {
     @objc func sendNewVPNIntent(_ value: SwitchedVPNStartStopIntent) {
         switch value.switchedIntent {
         case .start(transition: .none):
-            self.store.send(vpnAction: .tunnelStateIntent(.start(transition: .none)))
+            self.store.send(vpnAction: .tunnelStateIntent(
+                intent: .start(transition: .none), reason: .userInitiated
+            ))
         case .stop:
-            self.store.send(vpnAction: .tunnelStateIntent(.stop))
+            self.store.send(vpnAction: .tunnelStateIntent(
+                intent: .stop, reason: .userInitiated
+            ))
         default:
             fatalErrorFeedbackLog("Unexpected state '\(value.switchedIntent)'")
         }
     }
     
     @objc func restartVPNIfActive() {
-        self.store.send(vpnAction: .tunnelStateIntent(.start(transition: .restart)))
+        self.store.send(vpnAction: .tunnelStateIntent(
+            intent: .start(transition: .restart), reason: .userInitiated
+            ))
     }
     
     @objc func syncWithTunnelProvider(reason: TunnelProviderSyncReason) {

--- a/PsiphonVPN/PacketTunnelProvider.m
+++ b/PsiphonVPN/PacketTunnelProvider.m
@@ -555,6 +555,8 @@ typedef NS_ENUM(NSInteger, TunnelProviderState) {
     if (self.extensionStartMethod == ExtensionStartMethodFromContainer
         || self.extensionStartMethod == ExtensionStartMethodFromCrash
         || [self.subscriptionCheckState isSubscribedOrInProgress]) {
+        
+        [self.sharedDB setExtensionIsZombie:FALSE];
 
         if (![self.subscriptionCheckState isSubscribedOrInProgress] &&
             self.extensionStartMethod == ExtensionStartMethodFromContainer) {
@@ -587,6 +589,8 @@ typedef NS_ENUM(NSInteger, TunnelProviderState) {
         //
         // To potentially stop leaking sensitive traffic while in this state, we will route
         // the network to a dead-end by setting tunnel network settings and not starting Psiphon tunnel.
+        
+        [self.sharedDB setExtensionIsZombie:TRUE];
 
         [PsiFeedbackLogger info:@"zombie mode"];
 

--- a/Shared/PsiphonDataSharedDB.h
+++ b/Shared/PsiphonDataSharedDB.h
@@ -169,6 +169,11 @@ The integer values are defined in `NEBridge.h` with prefix `TUNNEL_INTENT_`.
  */
 - (void)updateServerTimestamp:(NSString *)timestamp;
 
+/**
+ * Set by the extension when initialized.
+ */
+- (void)setExtensionIsZombie:(BOOL)isZombie;
+
 #else
 
 - (NSArray<Homepage *> *_Nullable)getHomepages;
@@ -183,6 +188,10 @@ The integer values are defined in `NEBridge.h` with prefix `TUNNEL_INTENT_`.
 
 #endif
 
+/**
+ * Returns last value recorded by the extension with call to `setExtensionIsZombie:`.
+ */
+- (BOOL)getExtensionIsZombie;
 
 #pragma mark - Subscription
 

--- a/Shared/PsiphonDataSharedDB.m
+++ b/Shared/PsiphonDataSharedDB.m
@@ -41,6 +41,8 @@ UserDefaultsKey const TunnelSponsorIDStringKey = @"current_sponsor_id";
 
 UserDefaultsKey const ServerTimestampStringKey = @"server_timestamp";
 
+UserDefaultsKey const ExtensionIsZombieBoolKey = @"extensino_zombie";
+
 UserDefaultsKey const ContainerSubscriptionEmptyReceiptNumberKey = @"kContainerSubscriptionEmptyReceiptKey";
 
 UserDefaultsKey const ContainerSubscriptionReceiptExpiryDate = @"container_subscription_receipt_expiry_date";
@@ -358,6 +360,14 @@ UserDefaultsKey const DebugPsiphonConnectionStateStringKey = @"PsiphonDataShared
 - (void)updateServerTimestamp:(NSString*) timestamp {
     [sharedDefaults setObject:timestamp forKey:ServerTimestampStringKey];
     [sharedDefaults synchronize];
+}
+
+- (void)setExtensionIsZombie:(BOOL)isZombie {
+    [sharedDefaults setBool:isZombie forKey:ExtensionIsZombieBoolKey];
+}
+
+- (BOOL)getExtensionIsZombie {
+    return [sharedDefaults boolForKey:ExtensionIsZombieBoolKey];
 }
 
 - (NSArray<Homepage *> *_Nullable)getHomepages {


### PR DESCRIPTION
Motivation:
Previously tunnel would be stopped in case of a failed sync state
IPC between tunnel provider and the container app.
In light of the fact that these IPCs fail quite often, a more
passive approach should be taken.

Modifications:
- Tunnel provider records a flag in `PsiphonDataSharedDB` as to whether
  it is in a zombie state.
- On IPC failure, tunnel provider is stopped only if the zombie flag
  recorded in `PsiphonDataSharedDB` is true.
- Connection state at the time provider sync state is recorded,
  and used to initialize tunnel intent if not previous initialized,
  and that the IPC failed.
- Added more logging of IPC and tunnel intent change actions.

Result:
A less disruptive VPN experience.