### PR TITLE
Simplified iapReducer + WebOrderLineItemID

### DIFF
--- a/PsiApi/Sources/AppStoreIAP/AppStoreReceipt.swift
+++ b/PsiApi/Sources/AppStoreIAP/AppStoreReceipt.swift
@@ -54,7 +54,7 @@ public struct ProductID: TypedIdentifier {
     }
 }
 
-public struct ReceiptData: Equatable {
+public struct ReceiptData: Hashable {
     /// Subscription in-app purchases within the receipt that have not expired at the time of `readDate`.
     public let subscriptionInAppPurchases: Set<SubscriptionIAPPurchase>
     /// Consumables in-app purchases within the receipt.
@@ -78,6 +78,10 @@ public struct ReceiptData: Equatable {
     
     public static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.data == rhs.data
+    }
+    
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(data)
     }
     
 }

--- a/PsiApi/Sources/AppStoreIAP/AppStoreReceipt.swift
+++ b/PsiApi/Sources/AppStoreIAP/AppStoreReceipt.swift
@@ -43,6 +43,18 @@ public struct OriginalTransactionID: TypedIdentifier {
     }
 }
 
+/// Represents App Store in-app purchase `web_order_line_item_id` that uniquely identifies
+/// subscription purchases.
+public struct WebOrderLineItemID: TypedIdentifier {
+    public var rawValue: String { value }
+    
+    private let value: String
+    
+    public init?(rawValue: String) {
+        self.value = rawValue
+    }
+}
+
 /// Represents App Store in-app purchase product identifier.
 public struct ProductID: TypedIdentifier {
     public var rawValue: String { value }
@@ -120,6 +132,12 @@ public struct SubscriptionIAPPurchase: Hashable, Codable {
     /// - JSON Field Name: `original_transaction_id`
     public let originalTransactionID: OriginalTransactionID
     
+    /// The primary key for identifying subscription purchases.
+    /// - Note: ASN.1 Field value is INTEGER, however it is parsed as a string.
+    /// - ASN.1 Field Type: 1711
+    /// - JSON Field Name: `web_order_line_item_id`
+    public let webOrderLineItemID: WebOrderLineItemID
+    
     /// In an auto-renewable subscription receipt, the purchase date is the
     /// date when the subscription was either purchased or renewed (with or without a lapse).
     /// For an automatic renewal that occurs on the expiration date of the current period,
@@ -147,6 +165,7 @@ public struct SubscriptionIAPPurchase: Hashable, Codable {
         productID: ProductID,
         transactionID: TransactionID,
         originalTransactionID: OriginalTransactionID,
+        webOrderLineItemID: WebOrderLineItemID,
         purchaseDate: Date,
         expires: Date,
         isInIntroOfferPeriod: Bool,
@@ -155,6 +174,7 @@ public struct SubscriptionIAPPurchase: Hashable, Codable {
         self.productID = productID
         self.transactionID = transactionID
         self.originalTransactionID = originalTransactionID
+        self.webOrderLineItemID = webOrderLineItemID
         self.purchaseDate = purchaseDate
         self.expires = expires
         self.isInIntroOfferPeriod = isInIntroOfferPeriod

--- a/PsiApi/Sources/AppStoreIAP/IAPProducts.swift
+++ b/PsiApi/Sources/AppStoreIAP/IAPProducts.swift
@@ -285,10 +285,6 @@ extension PaymentTransaction.TransactionState {
     /// `shouldFinishTransactionImmediately` determines whether or not to
     /// call `finishTransaction(_:)` on an App Store IAP before any deliverables are delivered
     /// based on current transaction state and the provided `productType`.
-    ///
-    /// If returns `false` for a successful transaction, then the transaction should
-    /// Otherwise, for the given transaction, deliverables should be delivered to the user
-    /// and then transaction
     public func shouldFinishTransactionImmediately(
         productType: AppStoreProductType
     ) -> FinishAppStoreTransaction {

--- a/PsiApi/Sources/AppStoreIAP/IAPReducer.swift
+++ b/PsiApi/Sources/AppStoreIAP/IAPReducer.swift
@@ -435,10 +435,14 @@ public func iapReducer(
             if case .completed(_) = tx.transactionState(), case .subscription = productType {
                 let maybeError = state.iap.purchasing[productType]?.purchasingState.completed
                 
-                fulfillAll(promises: state.iap.objcSubscriptionPromises,
-                           with: ObjCIAPResult(transaction: tx.skPaymentTransaction()!, error: maybeError))
+                if state.iap.objcSubscriptionPromises.count > 0 {
+                    fulfillAll(promises: state.iap.objcSubscriptionPromises,
+                               with: ObjCIAPResult(transaction: tx.skPaymentTransaction()!,
+                                                   error: maybeError))
+                    
+                    state.iap.objcSubscriptionPromises = []
+                }
                 
-                state.iap.objcSubscriptionPromises = []
             }
             
             // Adds effect to finish current transaction `tx`.

--- a/PsiApi/Sources/AppStoreIAP/IAPReducer.swift
+++ b/PsiApi/Sources/AppStoreIAP/IAPReducer.swift
@@ -405,7 +405,7 @@ public func iapReducer(
                 getCurrentTime: environment.getCurrentTime
             )
             
-            // Updates purchasing state based on result of IAPPPurchasing.makeGiven.
+            // Updates purchasing state based on result of IAPPurchasing.makeGiven.
             switch iapPurchasingResult {
             case let .success(.unique(iapPurchasing, maybeUnfinishedConsumableTx)):
                 state.iap.purchasing[productType] = iapPurchasing

--- a/PsiApi/Sources/AppStoreIAP/IAPState.swift
+++ b/PsiApi/Sources/AppStoreIAP/IAPState.swift
@@ -166,7 +166,7 @@ public struct IAPState: Equatable {
     /// Contains products currently being purchased.
     public var purchasing: [AppStoreProductType: IAPPurchasing]
     
-    public var objcSubscriptionPromise: Promise<ObjCIAPResult>? = nil
+    public var objcSubscriptionPromises = [Promise<ObjCIAPResult>]()
     
     public init() {
         self.purchasing = [:]

--- a/PsiApi/Sources/AppStoreIAP/PaymentQueue.swift
+++ b/PsiApi/Sources/AppStoreIAP/PaymentQueue.swift
@@ -24,13 +24,13 @@ import PsiApi
 
 public struct PaymentQueue {
     public let transactions: () -> Effect<[PaymentTransaction]>
-    public let addPayment: (AppStoreProduct) -> Effect<AddedPayment>
+    public let addPayment: (AppStoreProduct) -> Effect<Never>
     public let addObserver: (SKPaymentTransactionObserver) -> Effect<Never>
     public let removeObserver: (SKPaymentTransactionObserver) -> Effect<Never>
     public let finishTransaction: (PaymentTransaction) -> Effect<Never>
     
     public init(transactions: @escaping () -> Effect<[PaymentTransaction]>,
-                addPayment: @escaping (AppStoreProduct) -> Effect<AddedPayment>,
+                addPayment: @escaping (AppStoreProduct) -> Effect<Never>,
                 addObserver: @escaping (SKPaymentTransactionObserver) -> Effect<Never>,
                 removeObserver: @escaping (SKPaymentTransactionObserver) -> Effect<Never>,
                 finishTransaction: @escaping (PaymentTransaction) -> Effect<Never>) {
@@ -39,18 +39,6 @@ public struct PaymentQueue {
         self.addObserver = addObserver
         self.removeObserver = removeObserver
         self.finishTransaction = finishTransaction
-    }
-    
-}
-
-/// Represents a payment that has been added to `SKPaymentQueue`.
-public struct AddedPayment: Equatable {
-    public let product: AppStoreProduct
-    public let payment: Payment
-    
-    public init(_ product: AppStoreProduct, _ payment: Payment) {
-        self.product = product
-        self.payment = payment
     }
     
 }

--- a/PsiApi/Sources/AppStoreIAP/Subscriptions/SubscriptionAuthState.swift
+++ b/PsiApi/Sources/AppStoreIAP/Subscriptions/SubscriptionAuthState.swift
@@ -335,6 +335,7 @@ public func subscriptionAuthStateReducer(
         let req = PurchaseVerifierServer.subscription(
          requestBody: SubscriptionValidationRequest(
              originalTransactionID: purchaseWithLatestExpiry.purchase.originalTransactionID,
+             productID: purchaseWithLatestExpiry.purchase.productID,
              receipt: receiptData
          ),
          clientMetaData: environment.clientMetaData

--- a/PsiApi/Sources/AppStoreIAP/Subscriptions/SubscriptionAuthState.swift
+++ b/PsiApi/Sources/AppStoreIAP/Subscriptions/SubscriptionAuthState.swift
@@ -538,7 +538,10 @@ public func subscriptionAuthStateReducer(
                 var effects = [Effect<SubscriptionAuthStateAction>]()
                 
                 effects.append(
-                    environment.feedbackLogger.log(.error, "authorization request failed '\(failureEvent)'").mapNever()
+                    environment.feedbackLogger.log(.error, """
+                        authorization request failed for original transaction id \
+                        '\(purchase.originalTransactionID)': error: '\(failureEvent)'
+                        """).mapNever()
                 )
                 
                 if case .badRequest = failureEvent.error {

--- a/PsiApi/Sources/AppStoreIAP/Subscriptions/SubscriptionAuthState.swift
+++ b/PsiApi/Sources/AppStoreIAP/Subscriptions/SubscriptionAuthState.swift
@@ -333,11 +333,12 @@ public func subscriptionAuthStateReducer(
         // Creates retriable authorization request.
 
         let req = PurchaseVerifierServer.subscription(
-         requestBody: SubscriptionValidationRequest(
-             originalTransactionID: purchaseWithLatestExpiry.purchase.originalTransactionID,
-             productID: purchaseWithLatestExpiry.purchase.productID,
-             receipt: receiptData
-         ),
+            requestBody: SubscriptionValidationRequest(
+                originalTransactionID: purchaseWithLatestExpiry.purchase.originalTransactionID,
+                webOrderLineItemID: purchaseWithLatestExpiry.purchase.webOrderLineItemID,
+                productID: purchaseWithLatestExpiry.purchase.productID,
+                receipt: receiptData
+            ),
          clientMetaData: environment.clientMetaData
         )
 

--- a/PsiApi/Sources/AppStoreIAP/Subscriptions/SubscriptionAuthState.swift
+++ b/PsiApi/Sources/AppStoreIAP/Subscriptions/SubscriptionAuthState.swift
@@ -132,10 +132,10 @@ public struct SubscriptionAuthState: Equatable {
 
     public init() {}
     
-    public typealias PurchaseAuthStateDict = [OriginalTransactionID: SubscriptionPurchaseAuthState]
+    public typealias PurchaseAuthStateDict = [WebOrderLineItemID: SubscriptionPurchaseAuthState]
 
     /// Set of transactions that either have a pending authorization request (either in-flight or pending tunnel connected).
-    public var transactionsPendingAuthRequest = Set<OriginalTransactionID>()
+    public var transactionsPendingAuthRequest = Set<WebOrderLineItemID>()
     
     /// `nil` represents that subscription auths have not been restored from previously stored value.
     /// This value is in  sync with stored value in  `PsiphonDataSharedDBContainer`
@@ -322,7 +322,7 @@ public func subscriptionAuthStateReducer(
         
         // Adds transaction ID to set of transaction IDs pending authorization request response.
         let (inserted, _) = state.subscription.transactionsPendingAuthRequest.insert(
-            purchaseWithLatestExpiry.purchase.originalTransactionID
+            purchaseWithLatestExpiry.purchase.webOrderLineItemID
         )
         
         // Guards that the an authorization request is not already made given the transaction ID.
@@ -369,20 +369,20 @@ public func subscriptionAuthStateReducer(
                 )
             },
             environment.feedbackLogger.log(.info, """
-                initiated auth request for original transaction ID \
-                \(purchaseWithLatestExpiry.purchase.originalTransactionID)
+                initiated auth request for webOrderLineItemID \
+                \(purchaseWithLatestExpiry.purchase.webOrderLineItemID)
                 """).mapNever()
         ]
         
     case let ._authorizationRequestResult(result: requestResult, forPurchase: purchase):
         guard
             state.subscription.transactionsPendingAuthRequest
-                .contains(purchase.originalTransactionID)
+                .contains(purchase.webOrderLineItemID)
             else {
                 return [
                     environment.feedbackLogger.log(.warn, """
                         'state.subscription.transactionsPendingAuthRequest' does not contains \
-                        purchase with original transaction ID: '\(purchase.originalTransactionID)'
+                        purchase with webOrderLineItemID: '\(purchase.webOrderLineItemID)'
                         """).mapNever()
                 ]
         }
@@ -391,18 +391,18 @@ public func subscriptionAuthStateReducer(
             fatalError()
         }
         
-        guard purchasesAuthState.contains(originalTransactionID: purchase.originalTransactionID)
+        guard purchasesAuthState.contains(webOrderLineItemID: purchase.webOrderLineItemID)
             else {
                 
                 // Removes the transaction from set of transactions pending auth request,
                 // as this transaction is no longer valid (since it is not part of the state).
                 state.subscription.transactionsPendingAuthRequest
-                    .remove(purchase.originalTransactionID)
+                    .remove(purchase.webOrderLineItemID)
                 
                 return [
                     environment.feedbackLogger.log(.warn, """
                         'state.subscription.purchaseAuthStates' does not contain purchase
-                        with original transaction ID: '\(purchase.originalTransactionID)'
+                        with webOrderLineItemID: '\(purchase.webOrderLineItemID)'
                         """).mapNever()
                 ]
         }
@@ -430,11 +430,11 @@ public func subscriptionAuthStateReducer(
             )
             
             // Authorization request for this purchase is no longer pending.
-            state.subscription.transactionsPendingAuthRequest.remove(purchase.originalTransactionID)
+            state.subscription.transactionsPendingAuthRequest.remove(purchase.webOrderLineItemID)
             
             let stateUpdateEffect = state.subscription.setAuthorizationState(
                 newValue: .requestError(errorEvent.eraseToRepr()),
-                forOriginalTransactionID: purchase.originalTransactionID,
+                forWebOrderLineItemID: purchase.webOrderLineItemID,
                 environment: environment
             )
             
@@ -448,24 +448,24 @@ public func subscriptionAuthStateReducer(
             // Authorization request completed with a response from purchase verifier server.
             
             // Authorization request for this purchase is no longer pending.
-            state.subscription.transactionsPendingAuthRequest.remove(purchase.originalTransactionID)
+            state.subscription.transactionsPendingAuthRequest.remove(purchase.webOrderLineItemID)
             
             switch subscriptionValidationResult {
                 
             case .success(let okResponse):
                 // 200-OK response from the purchase verifier server.
-                guard okResponse.originalTransactionID == purchase.originalTransactionID else {
+                guard okResponse.webOrderLineItemID == purchase.webOrderLineItemID else {
                     let log: LogMessage =
                         """
-                        sever transaction ID '\(okResponse.originalTransactionID)' did not match \
-                        expected transaction ID '\(purchase.originalTransactionID)'
+                        sever webOrderLineItemID '\(okResponse.webOrderLineItemID)' did not match \
+                        expected webOrderLineItemID '\(purchase.webOrderLineItemID)'
                         """
                     let err = ErrorEvent(ErrorRepr(repr:String(describing:log)),
                                          date: okResponse.requestDate)
                     return [
                         state.subscription.setAuthorizationState(
                             newValue: .requestError(err),
-                            forOriginalTransactionID: purchase.originalTransactionID,
+                            forWebOrderLineItemID: purchase.webOrderLineItemID,
                             environment: environment
                         ).mapNever(),
                         environment.feedbackLogger.log(.error, log).mapNever()
@@ -481,7 +481,7 @@ public func subscriptionAuthStateReducer(
                         return [
                             state.subscription.setAuthorizationState(
                                 newValue: .requestError(err),
-                                forOriginalTransactionID: purchase.originalTransactionID,
+                                forWebOrderLineItemID: purchase.webOrderLineItemID,
                                 environment: environment
                             ).mapNever(),
                             environment.feedbackLogger.log(.error, log).mapNever()
@@ -490,7 +490,7 @@ public func subscriptionAuthStateReducer(
                     
                     let stateUpdateEffect = state.subscription.setAuthorizationState(
                         newValue: .authorization(signedAuthorization),
-                        forOriginalTransactionID: okResponse.originalTransactionID,
+                        forWebOrderLineItemID: okResponse.webOrderLineItemID,
                         environment: environment
                     )
                     
@@ -507,7 +507,7 @@ public func subscriptionAuthStateReducer(
                 case .transactionExpired:
                     let stateUpdateEffect = state.subscription.setAuthorizationState(
                         newValue: .requestRejected(.transactionExpired),
-                        forOriginalTransactionID: okResponse.originalTransactionID,
+                        forWebOrderLineItemID: okResponse.webOrderLineItemID,
                         environment: environment
                     )
                     
@@ -522,7 +522,7 @@ public func subscriptionAuthStateReducer(
                 case .transactionCancelled:
                     let stateUpdateEffect = state.subscription.setAuthorizationState(
                         newValue: .requestRejected(.transactionCancelled),
-                        forOriginalTransactionID: okResponse.originalTransactionID,
+                        forWebOrderLineItemID: okResponse.webOrderLineItemID,
                         environment: environment
                     )
                     
@@ -541,15 +541,15 @@ public func subscriptionAuthStateReducer(
                 
                 effects.append(
                     environment.feedbackLogger.log(.error, """
-                        authorization request failed for original transaction id \
-                        '\(purchase.originalTransactionID)': error: '\(failureEvent)'
+                        authorization request failed for webOrderLineItemID \
+                        '\(purchase.webOrderLineItemID)': error: '\(failureEvent)'
                         """).mapNever()
                 )
                 
                 if case .badRequest = failureEvent.error {
                     let stateUpdateEffect = state.subscription.setAuthorizationState(
                         newValue: .requestRejected(.badRequestError),
-                        forOriginalTransactionID: purchase.originalTransactionID,
+                        forWebOrderLineItemID: purchase.webOrderLineItemID,
                         environment: environment
                     )
                     
@@ -558,7 +558,7 @@ public func subscriptionAuthStateReducer(
                 } else {
                     let stateUpdateEffect = state.subscription.setAuthorizationState(
                         newValue: .requestError(failureEvent.eraseToRepr()),
-                        forOriginalTransactionID: purchase.originalTransactionID,
+                        forWebOrderLineItemID: purchase.webOrderLineItemID,
                         environment: environment
                     )
                     
@@ -585,7 +585,7 @@ extension SubscriptionStatus {
     
 }
 
-extension Dictionary where Key == OriginalTransactionID, Value == SubscriptionPurchaseAuthState {
+extension Dictionary where Key == WebOrderLineItemID, Value == SubscriptionPurchaseAuthState {
     
     func updateAuthorizationState(
         givenRejectedAuthIDs rejectedAuthIDs: Set<AuthorizationID>
@@ -641,27 +641,27 @@ extension Dictionary where Key == OriginalTransactionID, Value == SubscriptionPu
     /// - Precondition: Each element `updatedPurchases` must have unique transaction ID.
     func merge(withUpdatedPurchases updatedPurchases: Set<SubscriptionIAPPurchase>) -> Self {
         
-        // updatedPurchases with latest expiry, hashed by OriginalTransactionID.
+        // updatedPurchases with latest expiry, hashed by WebOrderLineItemID.
         let altUpdatedPurchases = Set(updatedPurchases.sortedByExpiry().reversed().map {
-            HashableView($0, \.originalTransactionID)
+            HashableView($0, \.webOrderLineItemID)
         })
 
-        let updatedPurchasesDict = [OriginalTransactionID: SubscriptionIAPPurchase](
+        let updatedPurchasesDict = [WebOrderLineItemID: SubscriptionIAPPurchase](
             uniqueKeysWithValues: altUpdatedPurchases.map {
-                ($0.value.originalTransactionID, $0.value)
+                ($0.value.webOrderLineItemID, $0.value)
             }
         )
         return updatedPurchasesDict.mapValues {
             SubscriptionPurchaseAuthState(
                 purchase: $0,
-                signedAuthorization: self[$0.originalTransactionID]?.signedAuthorization ?? .notRequested
+                signedAuthorization: self[$0.webOrderLineItemID]?.signedAuthorization ?? .notRequested
             )
         }
     }
     
-    func contains(originalTransactionID: OriginalTransactionID) -> Bool {
+    func contains(webOrderLineItemID: WebOrderLineItemID) -> Bool {
         self.contains { (key, _) -> Bool in
-            key == originalTransactionID
+            key == webOrderLineItemID
         }
     }
     
@@ -700,19 +700,19 @@ extension SubscriptionAuthState {
     
     mutating func setAuthorizationState(
         newValue: SubscriptionPurchaseAuthState.AuthorizationState,
-        forOriginalTransactionID originalTransactionID: OriginalTransactionID,
+        forWebOrderLineItemID webOrderLineItemID: WebOrderLineItemID,
         environment: SubscriptionAuthStateReducerEnvironment
     ) -> Effect<Never> {
         guard var purchasesAuthState = self.purchasesAuthState else {
             fatalError()
         }
         
-        guard var currentValue = purchasesAuthState.removeValue(forKey: originalTransactionID) else{
-            fatalError("expected original transaction ID '\(originalTransactionID)'")
+        guard var currentValue = purchasesAuthState.removeValue(forKey: webOrderLineItemID) else{
+            fatalError("expected webOrderLineItemID '\(webOrderLineItemID)'")
         }
         
         currentValue.signedAuthorization = newValue
-        purchasesAuthState[originalTransactionID] = currentValue
+        purchasesAuthState[webOrderLineItemID] = currentValue
         return setPurchasesAuthState(newValue: purchasesAuthState, environment: environment)
     }
     
@@ -778,7 +778,7 @@ fileprivate enum StoredSubscriptionPurchasesAuthState {
     
     typealias StoredDataType = SubscriptionAuthState.PurchaseAuthStateDict
     
-    /// Returned effect emits stored data with type `[OriginalTransactionID, SubscriptionPurchaseAuthState]`.
+    /// Returned effect emits stored data with type `[WebOrderLineItemID, SubscriptionPurchaseAuthState]`.
     /// If there is no stored data, returns an empty dictionary.
     static func getValue(
         sharedDB: SharedDBContainer

--- a/PsiApi/Sources/AppStoreIAP/Subscriptions/SubscriptionPurchaseVerification.swift
+++ b/PsiApi/Sources/AppStoreIAP/Subscriptions/SubscriptionPurchaseVerification.swift
@@ -23,15 +23,21 @@ import PsiApi
 
 public struct SubscriptionValidationRequest: Codable {
     public let originalTransactionID: OriginalTransactionID
+    public let productID: ProductID
     let receiptData: String
     
-    public init(originalTransactionID: OriginalTransactionID, receipt: ReceiptData) {
+    public init(
+        originalTransactionID: OriginalTransactionID,
+        productID: ProductID,
+        receipt: ReceiptData) {
         self.originalTransactionID = originalTransactionID
+        self.productID = productID
         self.receiptData = receipt.data.base64EncodedString()
     }
     
     private enum CodingKeys: String, CodingKey {
         case originalTransactionID = "original_transaction_id"
+        case productID = "product_id"
         case receiptData = "receipt_data"
     }
 }

--- a/PsiApi/Sources/AppStoreIAP/Subscriptions/SubscriptionPurchaseVerification.swift
+++ b/PsiApi/Sources/AppStoreIAP/Subscriptions/SubscriptionPurchaseVerification.swift
@@ -61,6 +61,7 @@ public struct SubscriptionValidationResponse: RetriableHTTPResponse {
     public struct SuccessResult: Equatable, Codable {
         let requestDate: Date
         public let originalTransactionID: OriginalTransactionID
+        public let webOrderLineItemID: WebOrderLineItemID
         public let signedAuthorization: PsiApi.SignedData<SignedAuthorization>?
         public let errorStatus: ErrorStatus
         public let errorDescription: String
@@ -75,17 +76,23 @@ public struct SubscriptionValidationResponse: RetriableHTTPResponse {
         private enum CodingKeys: String, CodingKey {
             case requestDate = "request_date"
             case originalTransactionID = "original_transaction_id"
+            case webOrderLineItemID = "web_order_line_item_id"
             case signedAuthorization = "signed_authorization"
             case errorStatus = "error_status"
             case errorDescription = "error_description"
         }
 
-        public init(requestDate: Date, originalTransactionID: OriginalTransactionID,
-                    signedAuthorization: PsiApi.SignedData<SignedAuthorization>?,
-                    errorStatus: ErrorStatus, errorDescription: String) {
-
+        public init(
+            requestDate: Date,
+            originalTransactionID: OriginalTransactionID,
+            webOrderLineItemID: WebOrderLineItemID,
+            signedAuthorization: PsiApi.SignedData<SignedAuthorization>?,
+            errorStatus: ErrorStatus,
+            errorDescription: String
+        ) {
             self.requestDate = requestDate
             self.originalTransactionID = originalTransactionID
+            self.webOrderLineItemID = webOrderLineItemID
             self.signedAuthorization = signedAuthorization
             self.errorStatus = errorStatus
             self.errorDescription = errorDescription
@@ -96,6 +103,8 @@ public struct SubscriptionValidationResponse: RetriableHTTPResponse {
             requestDate = try values.decode(Date.self, forKey: .requestDate)
             originalTransactionID = try values.decode(OriginalTransactionID.self,
                                                       forKey: .originalTransactionID)
+            webOrderLineItemID = try values.decode(WebOrderLineItemID.self,
+                                                   forKey: .webOrderLineItemID)
             errorStatus = try values.decode(ErrorStatus.self, forKey: .errorStatus)
             errorDescription = try values.decode(String.self, forKey: .errorDescription)
             

--- a/PsiApi/Sources/AppStoreIAP/Subscriptions/SubscriptionPurchaseVerification.swift
+++ b/PsiApi/Sources/AppStoreIAP/Subscriptions/SubscriptionPurchaseVerification.swift
@@ -23,20 +23,25 @@ import PsiApi
 
 public struct SubscriptionValidationRequest: Codable {
     public let originalTransactionID: OriginalTransactionID
+    public let webOrderLineItemID: WebOrderLineItemID
     public let productID: ProductID
-    let receiptData: String
+    public let receiptData: String
     
     public init(
         originalTransactionID: OriginalTransactionID,
+        webOrderLineItemID: WebOrderLineItemID,
         productID: ProductID,
-        receipt: ReceiptData) {
+        receipt: ReceiptData
+    ) {
         self.originalTransactionID = originalTransactionID
+        self.webOrderLineItemID = webOrderLineItemID
         self.productID = productID
         self.receiptData = receipt.data.base64EncodedString()
     }
     
     private enum CodingKeys: String, CodingKey {
         case originalTransactionID = "original_transaction_id"
+        case webOrderLineItemID = "web_order_line_item_id"
         case productID = "product_id"
         case receiptData = "receipt_data"
     }

--- a/PsiApi/Sources/PsiApi/Error.swift
+++ b/PsiApi/Sources/PsiApi/Error.swift
@@ -24,7 +24,11 @@ import Utilities
 public typealias HashableError = Error & Hashable
 
 public struct FatalError: HashableError {
-    let message: String
+    public let message: LogMessage
+    
+    public init(_ message: LogMessage) {
+        self.message = message
+    }
 }
 
 /// String representation of a type-erased error.

--- a/PsiApi/Sources/PsiApi/Logging/FeedbackLogging.swift
+++ b/PsiApi/Sources/PsiApi/Logging/FeedbackLogging.swift
@@ -73,7 +73,7 @@ final class ArrayFeedbackLogHandler: FeedbackLogHandler {
 }
 
 public struct LogMessage: ExpressibleByStringLiteral, ExpressibleByStringInterpolation,
-Equatable, CustomStringConvertible, CustomStringFeedbackDescription, FeedbackDescription {
+Equatable, CustomStringConvertible, CustomStringFeedbackDescription, FeedbackDescription, Hashable {
     public typealias StringLiteralType = String
     
     private var value: String

--- a/PsiApi/Tests/AppStoreIAPTests/SubscriptionStateTest.swift
+++ b/PsiApi/Tests/AppStoreIAPTests/SubscriptionStateTest.swift
@@ -342,6 +342,7 @@ final class SubscriptionStateTest: XCTestCase {
             productID: ProductID(rawValue: "com.test.subscription1")!,
             transactionID: TransactionID(rawValue: UUID().uuidString)!,
             originalTransactionID: OriginalTransactionID(rawValue: "12345678")!,
+            webOrderLineItemID: WebOrderLineItemID(rawValue: "100012345678")!,
             purchaseDate: purchaseDate,
             expires: expires,
             isInIntroOfferPeriod: false,

--- a/PsiApi/Tests/PsiApiTestingCommon/AppStoreIAP+Arbitrary.swift
+++ b/PsiApi/Tests/PsiApiTestingCommon/AppStoreIAP+Arbitrary.swift
@@ -242,7 +242,9 @@ extension PaymentTransaction: Arbitrary {
             let transactionID: TransactionID = c.generate()
             let productID: ProductID = c.generate()
             let transactionState: TransactionState = c.generate()
-            let payment: Payment = c.generate()
+            let payment: Payment = c.generate(using:
+                Gen.pure(productID).map({Payment.init(productID: $0)})
+            )
             
             return PaymentTransaction(
                 transactionID: { transactionID },
@@ -256,20 +258,20 @@ extension PaymentTransaction: Arbitrary {
     }
 }
 
-extension UnverifiedPsiCashTransactionState.VerificationRequestState: Arbitrary {
-    public static var arbitrary: Gen<UnverifiedPsiCashTransactionState.VerificationRequestState> {
+extension UnfinishedConsumableTransaction.VerificationRequestState: Arbitrary {
+    public static var arbitrary: Gen<UnfinishedConsumableTransaction.VerificationRequestState> {
         Gen.one(of: [
             // Should cover all cases
             Gen.pure(.notRequested),
             Gen.pure(.pendingResponse),
             ErrorEvent<ErrorRepr>.arbitrary
-                .map(UnverifiedPsiCashTransactionState.VerificationRequestState.requestError),
+                .map(UnfinishedConsumableTransaction.VerificationRequestState.requestError),
         ])
     }
 }
 
-extension UnverifiedPsiCashTransactionState: Arbitrary {
-    public static var arbitrary: Gen<UnverifiedPsiCashTransactionState> {
+extension UnfinishedConsumableTransaction: Arbitrary {
+    public static var arbitrary: Gen<UnfinishedConsumableTransaction> {
         Gen.zip(PaymentTransaction.arbitrary, VerificationRequestState.arbitrary)
             .suchThat({ (paymentTransaction, _) -> Bool in
                 if case .completed(.success(_)) = paymentTransaction.transactionState() {
@@ -278,7 +280,7 @@ extension UnverifiedPsiCashTransactionState: Arbitrary {
                 return false
             }).map {
                 guard let value =
-                    UnverifiedPsiCashTransactionState(transaction: $0, verificationState: $1) else {
+                    UnfinishedConsumableTransaction(transaction: $0, verificationState: $1) else {
                         XCTFatal()
                 }
                 return value
@@ -385,7 +387,19 @@ extension IAPState: Arbitrary {
     public static var arbitrary: Gen<IAPState> {
         Gen.compose { c in
             IAPState(unverifiedPsiCashTx: c.generate(),
-                     purchasing: c.generate())
+                     purchasing: c.generate(using:
+                        [AppStoreProductType: IAPPurchasing].arbitrary
+                            .suchThat({ dict -> Bool in
+                                // The productType of the given key's value should
+                                // match the key.
+                                for key in dict.keys {
+                                    if dict[key]?.productType != key {
+                                        return false
+                                    }
+                                }
+                                return true
+                            })
+            ))
         }
     }
 }
@@ -499,7 +513,7 @@ extension IAPReducerState: Arbitrary {
     static let arbitraryWithPendingVerificationPurchaseState = Gen<IAPReducerState>.compose { c in
         IAPReducerState(
             iap: IAPState(
-                unverifiedPsiCashTx: c.generate(using:UnverifiedPsiCashTransactionState.arbitrary),
+                unverifiedPsiCashTx: c.generate(using:UnfinishedConsumableTransaction.arbitrary),
                 purchasing: c.generate()
             ),
             psiCashBalance: c.generate(),
@@ -524,14 +538,6 @@ extension IAPReducerState: Arbitrary {
         )
     }
     
-}
-
-extension AddedPayment: Arbitrary {
-    public static var arbitrary: Gen<AddedPayment> {
-        Gen.compose { c in
-            AddedPayment(c.generate(), c.generate())
-        }
-    }
 }
 
 extension PsiCashValidationResponse.ResponseError: Arbitrary {

--- a/PsiApi/Tests/PsiApiTestingCommon/AppStoreIAP+Arbitrary.swift
+++ b/PsiApi/Tests/PsiApiTestingCommon/AppStoreIAP+Arbitrary.swift
@@ -228,6 +228,15 @@ extension OriginalTransactionID: Arbitrary {
     }
 }
 
+extension WebOrderLineItemID: Arbitrary {
+    public static var arbitrary: Gen<WebOrderLineItemID> {
+        Int.arbitrary.resize(999_999_999).map {
+            WebOrderLineItemID.init(rawValue: String(abs($0)))!
+        }
+    }
+}
+
+
 extension Payment: Arbitrary {
     public static var arbitrary: Gen<Payment> {
         Gen.compose { c in
@@ -631,6 +640,7 @@ extension SubscriptionIAPPurchase: Arbitrary {
                 productID: c.generate(),
                 transactionID: c.generate(),
                 originalTransactionID: c.generate(),
+                webOrderLineItemID: c.generate(),
                 purchaseDate: c.generate(),
                 expires: c.generate(),
                 isInIntroOfferPeriod: c.generate(),

--- a/PsiApi/Tests/PsiApiTestingCommon/AppStoreIAPMockValues.swift
+++ b/PsiApi/Tests/PsiApiTestingCommon/AppStoreIAPMockValues.swift
@@ -63,16 +63,16 @@ extension PaymentQueue {
     
     static func mock(
         transactions: Gen<[PaymentTransaction]>? = nil,
-        addPayment: ((AppStoreProduct) -> AddedPayment)? = nil,
+        addPayment: ((AppStoreProduct) -> Effect<Never>)? = nil,
         finishTransaction: ((PaymentTransaction) -> Effect<Never>)? = nil
     ) -> PaymentQueue {
         return PaymentQueue(
             transactions: { () -> Effect<[PaymentTransaction]> in
                 Effect(value: returnGeneratedOrFail(transactions))
             },
-            addPayment: { product -> Effect<AddedPayment> in
+            addPayment: { product -> Effect<Never> in
                 guard let addPayment = addPayment else { XCTFatal() }
-                return Effect(value: addPayment(product))
+                return addPayment(product)
             },
             addObserver: { _ -> Effect<Never> in
                 return .empty

--- a/PsiApi/Tests/PsiApiTestingCommon/SubscriptionAuthState+Arbitrary.swift
+++ b/PsiApi/Tests/PsiApiTestingCommon/SubscriptionAuthState+Arbitrary.swift
@@ -130,7 +130,8 @@ extension SubscriptionAuthState: Arbitrary {
             if authStates.count > 0 {
                 subAuthState.purchasesAuthState = [:]
                 for purchaseAuthState in authStates {
-                    subAuthState.purchasesAuthState![purchaseAuthState.purchase.originalTransactionID] = purchaseAuthState
+                    let webOrderLineItemID = purchaseAuthState.purchase.webOrderLineItemID
+                    subAuthState.purchasesAuthState![webOrderLineItemID] = purchaseAuthState
                 }
             }
 

--- a/PsiApi/Tests/PsiApiTestingCommon/SubscriptionPurchaseVerification+Arbitrary.swift
+++ b/PsiApi/Tests/PsiApiTestingCommon/SubscriptionPurchaseVerification+Arbitrary.swift
@@ -153,6 +153,7 @@ extension SubscriptionValidationResponse.SuccessResult: Arbitrary {
             SubscriptionValidationResponse.SuccessResult(
                 requestDate: c.generate(),
                 originalTransactionID: c.generate(),
+                webOrderLineItemID: c.generate(),
                 signedAuthorization: c.generate(),
                 errorStatus: c.generate(),
                 errorDescription: c.generate())

--- a/Psiphon/AppAction+ValuePaths.swift
+++ b/Psiphon/AppAction+ValuePaths.swift
@@ -159,7 +159,8 @@ extension AppState {
                 pendingEffectCompletion: self.vpnState.pendingEffectCompletion,
                 value: VPNProviderManagerReducerState (
                     vpnState: self.vpnState.value,
-                    subscriptionTransactionsPendingAuthorization: self.subscriptionAuthState .transactionsPendingAuthRequest
+                    subscriptionTransactionsPendingAuthorization:
+                    self.subscriptionAuthState .transactionsPendingAuthRequest
                 )
             )
         }

--- a/Psiphon/AppStoreIAP+Additions.swift
+++ b/Psiphon/AppStoreIAP+Additions.swift
@@ -44,10 +44,9 @@ extension PaymentQueue {
             }
         },
         addPayment: { product in
-            Effect { () -> AddedPayment in
+            .fireAndForget {
                 let skPayment = SKPayment(product: product.skProductRef!)
                 SKPaymentQueue.default().add(skPayment)
-                return AddedPayment(product, Payment.from(skPayment: skPayment))
             }
         },
         addObserver: { observer in

--- a/Psiphon/AppStoreParsedReceiptData.h
+++ b/Psiphon/AppStoreParsedReceiptData.h
@@ -39,6 +39,15 @@
 @property (nonatomic, strong, readonly) NSDate *_Nonnull purchaseDate;
 
 /**
+ The Web Order Line Item ID for subscription.
+ 
+ This value is a unique ID that identifies purchase events across devices, including subscription renewal purchase events.
+ 
+ - Note: ASN.1 Field value is INTEGER, however it is parsed as a string.
+ */
+@property (nonatomic, strong, readonly) NSString *_Nullable webOrderLineItemID;
+
+/**
  The expiration date for the subscription.
  
  Only present for auto-renewable subscription receipts.

--- a/Psiphon/Receipt+AppStore.swift
+++ b/Psiphon/Receipt+AppStore.swift
@@ -84,6 +84,8 @@ extension ReceiptData {
                     transactionID: TransactionID(rawValue: parsedIAP.transactionID)!,
                     originalTransactionID: OriginalTransactionID(rawValue:
                         parsedIAP.originalTransactionID)!,
+                    webOrderLineItemID: WebOrderLineItemID(rawValue:
+                        parsedIAP.webOrderLineItemID!)!,
                     purchaseDate: parsedIAP.purchaseDate,
                     expires: parsedIAP.expiresDate!,
                     isInIntroOfferPeriod: parsedIAP.isInIntroPeriod,

--- a/Psiphon/VPNStateReducer.swift
+++ b/Psiphon/VPNStateReducer.swift
@@ -149,7 +149,7 @@ struct VPNProviderManagerState<T: TunnelProviderManager>: Equatable {
 
 struct VPNProviderManagerReducerState<T: TunnelProviderManager>: Equatable {
     var vpnState: VPNProviderManagerState<T>
-    let subscriptionTransactionsPendingAuthorization: Set<OriginalTransactionID>
+    let subscriptionTransactionsPendingAuthorization: Set<WebOrderLineItemID>
 }
 
 typealias VPNReducerEnvironment<T: TunnelProviderManager> = (

--- a/Psiphon/View/SubscriptionBarView.swift
+++ b/Psiphon/View/SubscriptionBarView.swift
@@ -207,12 +207,12 @@ extension SubscriptionBarView.SubscriptionBarState {
                 return .init(tunnelStatus: tunnelStatus, authState: .notSubscribed)
             }
             
-            let originalTxID = subscriptionPurchase.originalTransactionID
-            guard let purchaseState = purchasesAuthState[originalTxID] else {
+            let webOrderID = subscriptionPurchase.webOrderLineItemID
+            guard let purchaseState = purchasesAuthState[webOrderID] else {
                 return .init(tunnelStatus: tunnelStatus, authState: .notSubscribed)
             }
             
-            if authState.transactionsPendingAuthRequest.contains(originalTxID) {
+            if authState.transactionsPendingAuthRequest.contains(webOrderID) {
                 return .init(tunnelStatus: tunnelStatus, authState: .pending)
             } else {
                 

--- a/Psiphon/ViewControllers/PsiCashViewController.swift
+++ b/Psiphon/ViewControllers/PsiCashViewController.swift
@@ -316,7 +316,7 @@ final class PsiCashViewController: UIViewController {
                     case (.notConnected, .addPsiCash),
                          (.connected, .addPsiCash):
                         
-                        if let unverifiedPsiCashTx = observed.state.iap.unverifiedPsiCashTx {
+                        if let unverifiedPsiCashTx = observed.state.iap.unfinishedPsiCashTx {
                             switch observed.tunneled {
                             case .connected:
                                 


### PR DESCRIPTION
- Simplified iapReducer logic by refining types
- Fixed tests for iapReducer
- Fixed tests for SubscriptionAuthState
- Added ProductID as a request param to purchase-verifier /v2 subscription endpoint.
- Replaced usages of OriginalTransactionID with WebOrderLineItemID