### PR TITLE
Screenshot generation updates

### DIFF
--- a/Psiphon.xcodeproj/xcshareddata/xcschemes/PsiphonUITests.xcscheme
+++ b/Psiphon.xcodeproj/xcshareddata/xcschemes/PsiphonUITests.xcscheme
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1130"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CE26FC891BBDC7B800B83375"
+               BuildableName = "Psiphon.app"
+               BlueprintName = "Psiphon"
+               ReferencedContainer = "container:Psiphon.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CE26FC891BBDC7B800B83375"
+            BuildableName = "Psiphon.app"
+            BlueprintName = "Psiphon"
+            ReferencedContainer = "container:Psiphon.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4E0D88201FA06B2400ADB61E"
+               BuildableName = "PsiphonUITests.xctest"
+               BlueprintName = "PsiphonUITests"
+               ReferencedContainer = "container:Psiphon.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "PsiApiTests"
+               BuildableName = "PsiApiTests"
+               BlueprintName = "PsiApiTests"
+               ReferencedContainer = "container:PsiApi">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "TestingTests"
+               BuildableName = "TestingTests"
+               BlueprintName = "TestingTests"
+               ReferencedContainer = "container:Testing">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "UtilitiesTests"
+               BuildableName = "UtilitiesTests"
+               BlueprintName = "UtilitiesTests"
+               ReferencedContainer = "container:Utilities">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CEA1B777249AA9A0006D9853"
+               BuildableName = "PsiphonTests.xctest"
+               BlueprintName = "PsiphonTests"
+               ReferencedContainer = "container:Psiphon.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CE26FC891BBDC7B800B83375"
+            BuildableName = "Psiphon.app"
+            BlueprintName = "Psiphon"
+            ReferencedContainer = "container:Psiphon.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CE26FC891BBDC7B800B83375"
+            BuildableName = "Psiphon.app"
+            BlueprintName = "Psiphon"
+            ReferencedContainer = "container:Psiphon.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Psiphon/ViewControllers/MainViewController.m
+++ b/Psiphon/ViewControllers/MainViewController.m
@@ -882,11 +882,16 @@ NSTimeInterval const MaxAdLoadingTime = 10.f;
     versionLabel.userInteractionEnabled = FALSE;
     versionLabel.contentEdgeInsets = UIEdgeInsetsMake(padding, padding, padding, padding);
 
-# if DEBUG
+#if DEBUG
     versionLabel.userInteractionEnabled = TRUE;
     [versionLabel addTarget:self
                      action:@selector(onVersionLabelTap:)
            forControlEvents:UIControlEventTouchUpInside];
+    
+    if (AppInfo.runningUITest == TRUE) {
+        // Hide the version label when generating screenshots.
+        versionLabel.hidden = YES;
+    }
 #endif
     // Setup autolayout
     [NSLayoutConstraint activateConstraints:@[

--- a/PsiphonUITests/SnapshotHelper.swift
+++ b/PsiphonUITests/SnapshotHelper.swift
@@ -38,22 +38,13 @@ func snapshot(_ name: String, timeWaitingForIdle timeout: TimeInterval = 20) {
 }
 
 enum SnapshotError: Error, CustomDebugStringConvertible {
-    case cannotDetectUser
-    case cannotFindHomeDirectory
     case cannotFindSimulatorHomeDirectory
-    case cannotAccessSimulatorHomeDirectory(String)
     case cannotRunOnPhysicalDevice
 
     var debugDescription: String {
         switch self {
-        case .cannotDetectUser:
-            return "Couldn't find Snapshot configuration files - can't detect current user "
-        case .cannotFindHomeDirectory:
-            return "Couldn't find Snapshot configuration files - can't detect `Users` dir"
         case .cannotFindSimulatorHomeDirectory:
             return "Couldn't find simulator home location. Please, check SIMULATOR_HOST_HOME env variable."
-        case .cannotAccessSimulatorHomeDirectory(let simulatorHostHome):
-            return "Can't prepare environment. Simulator home location is inaccessible. Does \(simulatorHostHome) exist?"
         case .cannotRunOnPhysicalDevice:
             return "Can't use Snapshot on a physical device."
         }
@@ -75,7 +66,7 @@ open class Snapshot: NSObject {
         Snapshot.waitForAnimations = waitForAnimations
 
         do {
-            let cacheDir = try pathPrefix()
+            let cacheDir = try getCacheDirectory()
             Snapshot.cacheDirectory = cacheDir
             setLanguage(app)
             setLocale(app)
@@ -206,40 +197,28 @@ open class Snapshot: NSObject {
         _ = XCTWaiter.wait(for: [networkLoadingIndicatorDisappeared], timeout: timeout)
     }
 
-    class func pathPrefix() throws -> URL? {
-        let homeDir: URL
+    class func getCacheDirectory() throws -> URL {
+        let cachePath = "Library/Caches/tools.fastlane"
         // on OSX config is stored in /Users/<username>/Library
         // and on iOS/tvOS/WatchOS it's in simulator's home dir
         #if os(OSX)
-            guard let user = ProcessInfo().environment["USER"] else {
-                throw SnapshotError.cannotDetectUser
+            let homeDir = URL(fileURLWithPath: NSHomeDirectory())
+            return homeDir.appendingPathComponent(cachePath)
+        #elseif arch(i386) || arch(x86_64)
+            guard let simulatorHostHome = ProcessInfo().environment["SIMULATOR_HOST_HOME"] else {
+                throw SnapshotError.cannotFindSimulatorHomeDirectory
             }
-
-            guard let usersDir = FileManager.default.urls(for: .userDirectory, in: .localDomainMask).first else {
-                throw SnapshotError.cannotFindHomeDirectory
-            }
-
-            homeDir = usersDir.appendingPathComponent(user)
+            let homeDir = URL(fileURLWithPath: simulatorHostHome)
+            return homeDir.appendingPathComponent(cachePath)
         #else
-            #if arch(i386) || arch(x86_64)
-                guard let simulatorHostHome = ProcessInfo().environment["SIMULATOR_HOST_HOME"] else {
-                    throw SnapshotError.cannotFindSimulatorHomeDirectory
-                }
-                guard let homeDirUrl = URL(string: simulatorHostHome) else {
-                    throw SnapshotError.cannotAccessSimulatorHomeDirectory(simulatorHostHome)
-                }
-                homeDir = URL(fileURLWithPath: homeDirUrl.path)
-            #else
-                throw SnapshotError.cannotRunOnPhysicalDevice
-            #endif
+            throw SnapshotError.cannotRunOnPhysicalDevice
         #endif
-        return homeDir.appendingPathComponent("Library/Caches/tools.fastlane")
     }
 }
 
 private extension XCUIElementAttributes {
     var isNetworkLoadingIndicator: Bool {
-        if hasWhiteListedIdentifier { return false }
+        if hasAllowListedIdentifier { return false }
 
         let hasOldLoadingIndicatorSize = frame.size == CGSize(width: 10, height: 20)
         let hasNewLoadingIndicatorSize = frame.size.width.isBetween(46, and: 47) && frame.size.height.isBetween(2, and: 3)
@@ -247,10 +226,10 @@ private extension XCUIElementAttributes {
         return hasOldLoadingIndicatorSize || hasNewLoadingIndicatorSize
     }
 
-    var hasWhiteListedIdentifier: Bool {
-        let whiteListedIdentifiers = ["GeofenceLocationTrackingOn", "StandardLocationTrackingOn"]
+    var hasAllowListedIdentifier: Bool {
+        let allowListedIdentifiers = ["GeofenceLocationTrackingOn", "StandardLocationTrackingOn"]
 
-        return whiteListedIdentifiers.contains(identifier)
+        return allowListedIdentifiers.contains(identifier)
     }
 
     func isStatusBar(_ deviceWidth: CGFloat) -> Bool {
@@ -300,4 +279,4 @@ private extension CGFloat {
 
 // Please don't remove the lines below
 // They are used to detect outdated configuration files
-// SnapshotHelperVersion [1.21]
+// SnapshotHelperVersion [1.23]

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -13,15 +13,24 @@
 # Uncomment the line if you want fastlane to automatically update itself
 # update_fastlane
 
+# To run use: `fastlane ios screenshots`.
+
 default_platform(:ios)
 
 platform :ios do
   desc "Generate new localized screenshots"
   lane :screenshots do
     capture_ios_screenshots(workspace: "Psiphon.xcworkspace",
-                            scheme: "Psiphon",
+                            scheme: "PsiphonUITests",
                             stop_after_first_error: true,
+                            derived_data_path: "~/Library/Developer/Xcode/DerivedData/",
+                            # Do not rebuild for every device/language combination.
+                            test_without_building: true,
+                            concurrent_simulators: true,
                             dark_mode: true)
-    upload_to_app_store(skip_binary_upload: true, skip_metadata: true, screenshots_path: 'StoreAssets/screenshots')
+    upload_to_app_store(skip_binary_upload: true,
+                        skip_metadata: true, 
+                        overwrite_screenshots: true,
+                        screenshots_path: 'StoreAssets/screenshots')
   end
 end

--- a/fastlane/Snapfile
+++ b/fastlane/Snapfile
@@ -3,30 +3,11 @@
 
 # A list of devices you want to take the screenshots from
 devices([
-#  "iPhone 5s",
-#  "iPhone 6",
-#  "iPhone 6 Plus",
-   "iPhone 6s",
-#  "iPhone 6s Plus",
-#  "iPhone 7",
-#  "iPhone 7 Plus",
-   "iPhone 8",
-#  "iPhone 8 Plus",
-#  "iPad Air",
-#  "iPad Air 2",
-#  "iPad Air (3rd generation)",
-#  "iPad (5th generation)",
-#  "iPad (7th generation)",
-#  "iPad Pro (9.7 inch)",
-#  "iPad Pro (10.5-inch)",
-#  "iPad Pro (11-inch)",
-  "iPad Pro (12.9-inch)",
+  "iPhone 5s",
+  "iPhone 6s Plus",
+  "iPad Pro (12.9-inch) (2nd generation)",
   "iPad Pro (12.9-inch) (3rd generation)",
-  "iPhone X",
   "iPhone Xs Max",
-  "iPhone 11"
-#  "iPhone 11 Pro",
-#  "iPhone 11 Pro Max"
  ])
 
 languages([
@@ -66,7 +47,7 @@ languages([
 ])
 
 # The name of the scheme which contains the UI Tests
-scheme "Psiphon"
+scheme "PsiphonUITests"
 
 # Where should the resulting screenshots be stored?
 output_directory "./StoreAssets/screenshots"
@@ -80,9 +61,10 @@ clear_previous_screenshots true # remove the '#' to clear all previously generat
 # Arguments to pass to the app on launch. See https://docs.fastlane.tools/actions/snapshot/
 launch_arguments(["-FASTLANE_SNAPSHOT YES"])
 
+# In the past disabling concurrent simulators has helped fix issues
+# encountered when generating screenshots.
+# concurrent_simulators false
+
 # For more information about all available options run
 # fastlane snapshot --help
 
-# Disable concurrent simulators.
-# In the past running with concurrent simulators has caused issues.
-concurrent_simulators false

--- a/fastlane/generate_screenshots.sh
+++ b/fastlane/generate_screenshots.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e -u -x
+
+fastlane ios screenshots
+


### PR DESCRIPTION
- Update snapshot helper
- Do not rebuild project for every device/language combination
  - Speeds up screenshot generation by over 10x
- Hide version label when generating screenshots
- Overwrite existing screenshots on iTunes Connect
- re-enable concurrent simulators
- Create PsiphonUITests scheme for running UI tests