### PR TITLE
Fix allowing multiple refresh requests race-condition

### DIFF
--- a/Psiphon/PsiCash/PsiCashReducer.swift
+++ b/Psiphon/PsiCash/PsiCashReducer.swift
@@ -119,6 +119,9 @@ func psiCashReducer(
         guard case .completed(_) = state.psiCash.pendingPsiCashRefresh else {
             return []
         }
+        
+        state.psiCash.pendingPsiCashRefresh = .pending
+        
         return [
             environment.psiCashEffects
                 .refreshState(PsiCashTransactionClass.allCases, tunnelConnection)

--- a/Psiphon/PsiCashClient+Additions.swift
+++ b/Psiphon/PsiCashClient+Additions.swift
@@ -154,7 +154,7 @@ extension PsiCashEffects {
                         }
                         fulfilled(.completed(result))
                     }
-                }.prefix(value: .pending)
+                }
             },
             purchaseProduct: { [psiCash, feedbackLogger] (purchasable, tunnelConnection) -> Effect<PsiCashPurchaseResult> in
                 Effect.deferred { fulfilled in

--- a/Psiphon/SwiftDelegate.swift
+++ b/Psiphon/SwiftDelegate.swift
@@ -140,6 +140,8 @@ extension SwiftDelegate: SwiftBridgeDelegate {
     @objc func applicationDidFinishLaunching(
         _ application: UIApplication, objcBridge: ObjCBridgeDelegate
     ) {
+        self.feedbackLogger.immediate(.info, "applicationDidFinishLaunching")
+        
         self.objcBridge = objcBridge
         
         self.psiCashLib = PsiCash.make(flags: Debugging)

--- a/Psiphon/ViewControllers/RootContainerController.m
+++ b/Psiphon/ViewControllers/RootContainerController.m
@@ -115,6 +115,7 @@
     // once the loading is done.
     __block RACDisposable *disposable = [mainViewController.activeStateLoadingSignal
       subscribeNext:^(RACUnit *x) {
+          [PsiFeedbackLogger info:@"dismiss loading screen"];
           [weakSelf removeLaunchScreen];
       } error:^(NSError *error) {
           [weakSelf.compoundDisposable removeDisposable:disposable];


### PR DESCRIPTION
This fixes race-condition between PsiCash refresh state effect
emitting pending, and another refresh request being processed
by the PsiCash reducer.

The pending state is used as a guard to stop another refresh request
to be made while another one is in transit.