### PR TITLE
Fix extension crash if selected region becomes unavailable

### DIFF
--- a/PsiphonVPN/PacketTunnelProvider.m
+++ b/PsiphonVPN/PacketTunnelProvider.m
@@ -246,8 +246,12 @@ typedef NS_ENUM(NSInteger, TunnelProviderState) {
     });
 }
 
+// This method is not thread-safe.
 - (NSError *_Nullable)startPsiphonTunnel {
-
+    
+    // Indicates that a new tunnel session is about to begin.
+    [self->sessionConfigValues explicitlySetNewSession];
+    
     BOOL success = [self.psiphonTunnel start:FALSE];
 
     if (!success) {

--- a/PsiphonVPN/SessionConfigValues.h
+++ b/PsiphonVPN/SessionConfigValues.h
@@ -68,12 +68,16 @@ typedef NS_ENUM(NSInteger, AuthorizationUpdateResult) {
 // to `-newSessionEncodedAuthsWithSponsorID:` for the first time.
 - (AuthorizationUpdateResult)updateStoredAuthorizations;
 
+// Explicitly indicates that a new tunnel session is about to be started.
+- (void)explicitlySetNewSession;
+
 // Indicates start of a new tunnel session.
 //
 // Returns array of authorizations to be passed to tunnel-core, and populates `sponsorID`
 // with the appropriate value depending on the authorizations present.
 //
-// - Important: Throws an exception if this function is called more than once, unless
+// - Important: Throws an exception if this function is called more than once at the start
+// of a tunnel session, unless `newSession` is called beforehand or
 // call to `updateStoredAuthorizations` returns AuthorizationUpdateResultNewAuthsAvailable.
 - (NSArray<NSString *> *)
 newSessionEncodedAuthsWithSponsorID:(NSString *_Nonnull *_Nullable)sponsorID;


### PR DESCRIPTION
Modifications:
- Add `-explicitlySetNewSession` to indicate a new PsiphonTunnel
  session.
- Explicitly set that a new session has started by a call to
  `explicitlySetNewSession` in `startPsiphonTunnel`.
- Fix comments