### PR TITLE
Generate feedback ID once per user feedback upload

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -11,7 +11,7 @@ target 'Psiphon' do
   pod "InAppSettingsKit", :git => "https://github.com/Psiphon-Inc/InAppSettingsKit.git", :commit => '8bd203c'
   #pod "InAppSettingsKit", :path => "../InAppSettingsKit"
   #pod "PsiphonClientCommonLibrary", :path => "../psiphon-ios-client-common-library"
-  pod 'PsiphonClientCommonLibrary', :git => "https://github.com/Psiphon-Inc/psiphon-ios-client-common-library.git", :commit => '1194280'
+  pod 'PsiphonClientCommonLibrary', :git => "https://github.com/Psiphon-Inc/psiphon-ios-client-common-library.git", :commit => '593c5a6'
 
   # Swift dependencies
   pod 'ReactiveObjC', :git => "https://github.com/Psiphon-Inc/ReactiveObjC.git", :commit => '8bbf9dd'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -3,7 +3,7 @@ PODS:
   - InAppSettingsKit (2.15)
   - MBProgressHUD (1.1.0)
   - PersonalizedAdConsent (1.0.5)
-  - PsiphonClientCommonLibrary (3.0.0):
+  - PsiphonClientCommonLibrary (4.0.0):
     - InAppSettingsKit (= 2.15)
   - ReactiveObjC (3.1.0)
   - SVProgressHUD (2.2.5)
@@ -13,7 +13,7 @@ DEPENDENCIES:
   - InAppSettingsKit (from `https://github.com/Psiphon-Inc/InAppSettingsKit.git`, commit `8bd203c`)
   - MBProgressHUD (~> 1.1.0)
   - PersonalizedAdConsent (~> 1.0)
-  - PsiphonClientCommonLibrary (from `https://github.com/Psiphon-Inc/psiphon-ios-client-common-library.git`, commit `1194280`)
+  - PsiphonClientCommonLibrary (from `https://github.com/Psiphon-Inc/psiphon-ios-client-common-library.git`, commit `593c5a6`)
   - ReactiveObjC (from `https://github.com/Psiphon-Inc/ReactiveObjC.git`, commit `8bbf9dd`)
   - SVProgressHUD (~> 2.2.5)
 
@@ -29,7 +29,7 @@ EXTERNAL SOURCES:
     :commit: 8bd203c
     :git: https://github.com/Psiphon-Inc/InAppSettingsKit.git
   PsiphonClientCommonLibrary:
-    :commit: '1194280'
+    :commit: 593c5a6
     :git: https://github.com/Psiphon-Inc/psiphon-ios-client-common-library.git
   ReactiveObjC:
     :commit: 8bbf9dd
@@ -40,7 +40,7 @@ CHECKOUT OPTIONS:
     :commit: 8bd203c
     :git: https://github.com/Psiphon-Inc/InAppSettingsKit.git
   PsiphonClientCommonLibrary:
-    :commit: '1194280'
+    :commit: 593c5a6
     :git: https://github.com/Psiphon-Inc/psiphon-ios-client-common-library.git
   ReactiveObjC:
     :commit: 8bbf9dd
@@ -51,10 +51,10 @@ SPEC CHECKSUMS:
   InAppSettingsKit: 4890a44f9df7a1742c632920f0ea939cbeb29ea2
   MBProgressHUD: e7baa36a220447d8aeb12769bf0585582f3866d9
   PersonalizedAdConsent: dbecabb3467df967c16d9cebc2ef4a8890e4bbd8
-  PsiphonClientCommonLibrary: bbef27228ea9756933a189d7ab5088df35c5889a
+  PsiphonClientCommonLibrary: f8463a8fcc1b3dae81d18340a1c047b443867da2
   ReactiveObjC: 2a38ea15335de4119d8b17caf1db1484f61db902
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
 
-PODFILE CHECKSUM: be5b26e8186c186db4e5779eb1f52b17a629c901
+PODFILE CHECKSUM: 9e05834e039c5514575f7c7b431a765b20fa37d1
 
 COCOAPODS: 1.8.4

--- a/Psiphon/Feedback.swift
+++ b/Psiphon/Feedback.swift
@@ -50,14 +50,16 @@ public struct UserFeedback: Equatable {
     let email: String
     let uploadDiagnostics: Bool
     let submitTime: Date
+    let feedbackId: String
 
     public init(selectedThumbIndex: Int, comments: String, email: String,
-                uploadDiagnostics: Bool, submitTime: Date) {
+                uploadDiagnostics: Bool, feedbackId: String, submitTime: Date) {
 
         self.selectedThumbIndex = selectedThumbIndex
         self.comments = comments
         self.email = email
         self.uploadDiagnostics = uploadDiagnostics
+        self.feedbackId = feedbackId
         self.submitTime = submitTime;
     }
 }
@@ -310,9 +312,10 @@ func feedbackJSON(userFeedback: UserFeedback,
                 comments: userFeedback.comments,
                 email: userFeedback.email,
                 sendDiagnosticInfo: userFeedback.uploadDiagnostics,
-                withPsiphonConfig: psiphonConfig,
-                withClientPlatform: "ios-vpn",
-                withConnectionType: reachabilityStatus.connectionTypeForFeedback,
+                feedbackId: userFeedback.feedbackId,
+                psiphonConfig: psiphonConfig,
+                clientPlatform: "ios-vpn",
+                connectionType: reachabilityStatus.connectionTypeForFeedback,
                 isJailbroken: JailbreakCheck.isDeviceJailbroken(),
                 diagnosticEntries: diagnosticEntries,
                 statusEntries: .none)

--- a/Psiphon/FeedbackReducer.swift
+++ b/Psiphon/FeedbackReducer.swift
@@ -148,9 +148,9 @@ public func feedbackReducer(
         return []
     case .userSubmittedFeedback(let selectedThumbIndex, let comments, let email, let uploadDiagnostics):
         // Generate feedback ID once per user feedback.
-        // Using the same feedback ID for each upload attempt makes it easier to identify feedbacks
-        // which are uploaded more than once, e.g. the upload succeeds but the connection with the
-        // server is disrupted before the response is received by the client.
+        // Using the same feedback ID for each upload attempt makes it easier to identify when a
+        // feedback has been uploaded more than once, e.g. the upload succeeds but the connection
+        // with the server is disrupted before the response is received by the client.
         guard let randomFeedbackId = Feedback.generateId() else {
             return [
                 environment.feedbackLogger.log(.error, "failed to generate random feedback ID").mapNever()
@@ -289,12 +289,12 @@ fileprivate func sendFeedback(userFeedback: UserFeedback,
 
                             // Note: It is possible that the upload could succeed at the same moment
                             // one of the trigger signals (VPN state change, etc.) changes. Then
-                            // there would be a race between the this signal emitting a value and
-                            // it being disposed of, which would result in the value being ignored.
-                            // If this happens, the feedback upload will be attempted again even
-                            // though it already succeeded. For this reason the same feedback ID is
-                            // used for all upload attempts, which will provide visibility into
-                            // these occurrences and allow for mitigation.
+                            // there would be a race between this signal emitting a value and it
+                            // being disposed of, which would result in the value being ignored. If
+                            // this happens, the feedback upload will be attempted again even though
+                            // it already succeeded. For this reason the same feedback ID is used
+                            // for all upload attempts, which will provide visibility into these
+                            // occurrences and allow for mitigation.
                             return
                                 feedbackUpload.sendFeedback(feedbackJson: feedbackJSON,
                                                             feedbackConfigJson: psiphonConfig)

--- a/Shared/ExtensionContainerFile.h
+++ b/Shared/ExtensionContainerFile.h
@@ -50,7 +50,7 @@ typedef NS_ERROR_ENUM(ContainerReaderRotatedFileErrorDomain, ContainerReaderRota
 /// @param olderFilepath Location of rotated file.
 /// @param registryFilepath Filepath at which to store the registry file (which is used to track file reads).
 /// @param readChunkSize Number of bytes to read at a time.
-/// @param outError  If non-nill on return, then initializing the reader failed with the provided error.
+/// @param outError  If non-nil on return, then initializing the reader failed with the provided error.
 /// @return Returns nil when `outError` is non-nil.
 - (nullable instancetype)initWithFilepath:(NSString*)filepath
                             olderFilepath:(NSString*)olderFilepath
@@ -59,12 +59,12 @@ typedef NS_ERROR_ENUM(ContainerReaderRotatedFileErrorDomain, ContainerReaderRota
                                     error:(NSError * _Nullable *)outError;
 
 /// Read the next line. Lines are read back in the other in which they were written.
-/// @param outError If non-nill on return, then reading failed with the provided error.
+/// @param outError If non-nil on return, then reading failed with the provided error.
 /// @returns nil if there is no more data to read.
 - (NSString*_Nullable)readLineWithError:(NSError * _Nullable *)outError;
 
 /// Persist the registry to disk.
-/// @param outError If non-nill on return, then persisting the registry failed with the provided error.
+/// @param outError If non-nil on return, then persisting the registry failed with the provided error.
 - (void)persistRegistry:(NSError * _Nullable *)outError;
 
 @end
@@ -87,7 +87,7 @@ typedef NS_ERROR_ENUM(ExtensionWriterRotatedFileErrorDomain, ExtensionWriterRota
 /// @param filepath Filepath where the file should be created or appended to if it already exists.
 /// @param olderFilepath Filepath where the file should be rotated when it exceeds the configured max filesize.
 /// @param maxFileSizeBytes Configured max filesize.
-/// @param outError If non-nill on return, then initializing the writer failed with the provided error.
+/// @param outError If non-nil on return, then initializing the writer failed with the provided error.
 /// @return Returns nil when `outError` is non-nil.
 - (nullable instancetype)initWithFilepath:(NSString*)filepath
                             olderFilepath:(NSString*)olderFilepath
@@ -96,7 +96,7 @@ typedef NS_ERROR_ENUM(ExtensionWriterRotatedFileErrorDomain, ExtensionWriterRota
 
 /// Write data to the rotated file. The file will be rotated before writing if its size has exceeded the configured max filesize.
 /// @param data Data to write.
-/// @param outError If non-nill on return, then writing data failed with the provided error.
+/// @param outError If non-nil on return, then writing data failed with the provided error.
 - (void)writeData:(NSData*)data error:(NSError * _Nullable *)outError;
 
 @end

--- a/Shared/JetsamMetrics/JetsamTracking.h
+++ b/Shared/JetsamMetrics/JetsamTracking.h
@@ -54,7 +54,7 @@ typedef NS_ERROR_ENUM(ContainerJetsamTrackingErrorDomain, ContainerJetsamTrackin
 /// @param registryFilepath Filepath at which to store the registry file (which is used to track file reads).
 /// @param readChunkSize Number of bytes to read at a time.
 /// @param binRanges A collection of bin ranges in which to bin jetsam times.
-/// @param outError  If non-nill on return, then initializing the reader failed with the provided error.
+/// @param outError  If non-nil on return, then initializing the reader failed with the provided error.
 /// @return Returns nil when `outError` is non-nil.
 + (JetsamMetrics *_Nullable)getMetricsFromFilePath:(NSString*)filepath
                                withRotatedFilepath:(NSString*)rotatedFilepath
@@ -85,7 +85,7 @@ typedef NS_ERROR_ENUM(ExtensionJetsamTrackingErrorDomain, ExtensionJetsamTrackin
 /// @param filepath File where the event should be logged.
 /// @param rotatedFilepath Filepath where the logfile should be rotated to when it exceeds the configured max filesize.
 /// @param maxFilesizeBytes Configured max filesize.
-/// @param outError If non-nill on return, then logging the jetsam event failed with the provided error.
+/// @param outError If non-nil on return, then logging the jetsam event failed with the provided error.
 + (void)logJetsamEvent:(JetsamEvent*)jetsamEvent
             toFilepath:(NSString*)filepath
    withRotatedFilepath:(NSString*)rotatedFilepath

--- a/Shared/Util/Archiver.h
+++ b/Shared/Util/Archiver.h
@@ -33,14 +33,14 @@ typedef NS_ERROR_ENUM(ArchiverErrorDomain, ArchiverFileErrorCode) {
 
 /// Archives the given object with a keyed archiver.
 /// @param object Object to archive.
-/// @param outError If non-nill on return, then initialization failed with the provided error.
+/// @param outError If non-nil on return, then initialization failed with the provided error.
 /// @return Returns nil when `outError` is non-nil.
 + (nullable NSData *)archiveObject:(id<NSCoding, NSSecureCoding>)object
                              error:(NSError * _Nullable *)outError;
 
 /// Unarchives the given object with a keyed archiver.
 /// @param data Data which represents a keyed archive.
-/// @param outError If non-nill on return, then initialization failed with the provided error.
+/// @param outError If non-nil on return, then initialization failed with the provided error.
 /// @return Returns nil when `outError` is non-nil.
 + (nullable id)unarchiveObjectWithData:(NSData*)data
                                  error:(NSError * _Nullable *)outError;

--- a/Shared/Util/DelimitedFile.h
+++ b/Shared/Util/DelimitedFile.h
@@ -47,14 +47,14 @@ typedef NS_ERROR_ENUM(DelimitedFileErrorDomain, DelimitedFileErrorCode) {
 /// Init the reader.
 /// @param filepath Location of the file to be read.
 /// @param chunkSize Number of bytes to read from the file at a time.
-/// @param outError If non-nill on return, then initialization failed with the provided error.
+/// @param outError If non-nil on return, then initialization failed with the provided error.
 /// @return Returns nil when `outError` is non-nil.
 - (nullable instancetype)initWithFilepath:(NSString*)filepath
                                 chunkSize:(NSUInteger)chunkSize
                                     error:(NSError * _Nullable *)outError NS_DESIGNATED_INITIALIZER;
 
 /// Read a line from the file.
-/// @param outError If non-nill on return, then reading data failed with the provided error.
+/// @param outError If non-nil on return, then reading data failed with the provided error.
 /// @return Returns nil when all lines have been read or `outError` is non-nil.
 - (NSString*_Nullable)readLineWithError:(NSError * _Nullable *)outError;
 

--- a/Shared/Util/DiskBackedFile.h
+++ b/Shared/Util/DiskBackedFile.h
@@ -44,14 +44,14 @@ typedef NS_ERROR_ENUM(DiskBackedFileErrorDomain, DiskBackedFileErrorCode) {
 
 /// Return the data contained within the file at the specified path.
 /// @param filepath Path of the file that should be read from.
-/// @param outError If non-nill on return, then writing data failed with the provided error.
+/// @param outError If non-nil on return, then writing data failed with the provided error.
 /// @return Returns nil when `outError` is non-nil.
 + (NSData *_Nullable)fileDataAtPath:(NSString*)filepath error:(NSError * _Nullable *)outError;
 
 /// Create file with given data.
 /// @param filepath Filepath to write to. If a file exists at this path, it will be overwritten.
 /// @param data Data to write.
-/// @param outError If non-nill on return, then writing data failed with the provided error.
+/// @param outError If non-nil on return, then writing data failed with the provided error.
 + (void)createFileAtPath:(NSString*)filepath
                     data:(NSData*)data
                    error:(NSError * _Nullable *)outError;
@@ -59,7 +59,7 @@ typedef NS_ERROR_ENUM(DiskBackedFileErrorDomain, DiskBackedFileErrorCode) {
 /// Append data to file.
 /// @param filepath Filepath of file to append to.
 /// @param data Data to append.
-/// @param outError If non-nill on return, then writing data failed with the provided error.
+/// @param outError If non-nil on return, then writing data failed with the provided error.
 + (void)appendDataToFileAtPath:(NSString*)filepath
                           data:(NSData*)data
                          error:(NSError * _Nullable *)outError;
@@ -67,7 +67,7 @@ typedef NS_ERROR_ENUM(DiskBackedFileErrorDomain, DiskBackedFileErrorCode) {
 /// Write data to file.
 /// @param filepath Filepath of file to write to.
 /// @param data Data to write.
-/// @param outError If non-nill on return, then writing data failed with the provided error.
+/// @param outError If non-nil on return, then writing data failed with the provided error.
 + (void)writeDataToFileAtPath:(NSString*)filepath
                          data:(NSData*)data
                         error:(NSError * _Nullable *)outError;

--- a/Shared/Util/JSONCodable.h
+++ b/Shared/Util/JSONCodable.h
@@ -38,7 +38,7 @@ typedef NS_ERROR_ENUM(JSONCodableErrorDomain, JSONCodableErrorCode) {
 
 /// Recreate object from JSON dictionary.
 /// @param dict Dictionary valid for JSON de-/serialization with NSJSONSerialization (see NSJSONSerialization:isValidJSONObject:).
-/// @param outError If non-nill on return, then initialization failed with the provided error.
+/// @param outError If non-nil on return, then initialization failed with the provided error.
 /// @return Returns nil when `outError` is non-nil.
 + (id)jsonCodableObjectFromJSONDictionary:(NSDictionary*)dict
                                     error:(NSError *_Nullable *)outError;
@@ -50,7 +50,7 @@ typedef NS_ERROR_ENUM(JSONCodableErrorDomain, JSONCodableErrorCode) {
 
 /// Encode object to JSON data.
 /// @param object Object to encode.
-/// @param outError If non-nill on return, then initialization failed with the provided error.
+/// @param outError If non-nil on return, then initialization failed with the provided error.
 /// @return Returns nil when `outError` is non-nil.
 + (NSData *_Nullable)jsonCodableEncodeObject:(id<JSONCodable>)object
                                        error:(NSError *_Nullable *)outError;
@@ -58,7 +58,7 @@ typedef NS_ERROR_ENUM(JSONCodableErrorDomain, JSONCodableErrorCode) {
 /// Decode object from JSON data.
 /// @param aClass JSONCodable class to decode.
 /// @param data Data to decode.
-/// @param outError If non-nill on return, then initialization failed with the provided error.
+/// @param outError If non-nil on return, then initialization failed with the provided error.
 /// @return Returns nil when `outError` is non-nil.
 + (id _Nullable)jsonCodableDecodeObjectofClass:(Class<JSONCodable>)aClass
                                           data:(NSData*)data

--- a/Shared/Util/RotatingFile.h
+++ b/Shared/Util/RotatingFile.h
@@ -32,7 +32,7 @@ FOUNDATION_EXPORT NSErrorDomain const RotatingFileErrorDomain;
 /// @param filepath Path of file which will be written.
 /// @param olderFilepath Path where `filepath` will be moved once it exceeds `maxFileSizeBytes`.
 /// @param maxFileSizeBytes Maximum number of bytes that will be stored in the rotated file.
-/// @param outError If non-nill on return, then initialization failed with the provided error.
+/// @param outError If non-nil on return, then initialization failed with the provided error.
 /// @return Returns nil when `outError` is non-nil.
 - (nullable instancetype)initWithFilepath:(NSString *)filepath
                             olderFilepath:(NSString *)olderFilepath
@@ -44,7 +44,7 @@ FOUNDATION_EXPORT NSErrorDomain const RotatingFileErrorDomain;
 /// then the file will first be rotated (to `olderFilepath`) and then a new file will be created with
 /// the provided data (at `filepath`).
 /// @param data Data to be written.
-/// @param outError If non-nill on return, then writing data failed with the provided error.
+/// @param outError If non-nil on return, then writing data failed with the provided error.
 - (void)writeData:(NSData *)data error:(NSError * _Nullable *)outError;
 
 @end


### PR DESCRIPTION
- Previously a new feedback ID would be generated each time the feedback upload
  was attempted. Using the same ID will make it easier to identify feedbacks
  which are uploaded more than once, e.g. the upload succeeds but the
  connection is disrupted before the status code can be returned.