### PR TITLE
Added forced PsiCash state refresh for subscribed users

### DIFF
--- a/PsiApi/Sources/AppStoreIAP/IAPReducer.swift
+++ b/PsiApi/Sources/AppStoreIAP/IAPReducer.swift
@@ -355,7 +355,7 @@ public let iapReducer = Reducer<IAPReducerState, IAPAction, IAPEnvironment> {
                 // Finishes the transaction, and refreshes PsiCash state for the latest balance.
                 return [
                     environment.paymentQueue.finishTransaction(requestTransaction).mapNever(),
-                    environment.psiCashStore(.refreshPsiCashState).mapNever(),
+                    environment.psiCashStore(.refreshPsiCashState()).mapNever(),
                     environment.feedbackLogger.log(.info, "verified consumable transaction: '\(requestTransaction)'")
                     .mapNever()
                 ]

--- a/PsiApi/Sources/PsiCashClient/PsiCashReducerActions.swift
+++ b/PsiApi/Sources/PsiCashClient/PsiCashReducerActions.swift
@@ -34,7 +34,7 @@ public enum PsiCashAction: Equatable {
             result: PsiCashEffects.NewExpiringPurchaseResult
          )
     
-    case refreshPsiCashState
+    case refreshPsiCashState(ignoreSubscriptionState: Bool = false)
     case _refreshPsiCashStateResult(PsiCashEffects.PsiCashRefreshResult)
     
     case accountLogout

--- a/Psiphon/AppAction+ValuePaths.swift
+++ b/Psiphon/AppAction+ValuePaths.swift
@@ -295,6 +295,7 @@ extension AppState {
         get {
             MainViewReducerState(
                 mainView: self.mainView,
+                subscriptionState: self.subscription,
                 psiCashAccountType: self.psiCash.libData.accountType,
                 appLifecycle: self.appDelegateState.appLifecycle
             )

--- a/Psiphon/AppState.swift
+++ b/Psiphon/AppState.swift
@@ -497,6 +497,7 @@ fileprivate func toVPNReducerEnvironment(env: AppEnvironment) -> VPNReducerEnvir
 
 fileprivate func toMainViewReducerEnvironment(env: AppEnvironment) -> MainViewEnvironment {
     MainViewEnvironment(
+        psiCashStore: env.psiCashStore,
         psiCashViewEnvironment: PsiCashViewEnvironment(
             feedbackLogger: env.feedbackLogger,
             iapStore: env.iapStore,

--- a/Psiphon/SwiftDelegate.swift
+++ b/Psiphon/SwiftDelegate.swift
@@ -389,7 +389,7 @@ extension SwiftDelegate: SwiftBridgeDelegate {
         self.lifetime += self.store.$value.signalProducer.map(\.vpnState.value.vpnStatus)
             .skipRepeats()
             .filter { $0 == .connected }
-            .map(value: AppAction.psiCash(.refreshPsiCashState))
+            .map(value: AppAction.psiCash(.refreshPsiCashState()))
             .send(store: self.store)
         
         // Maps connected events to rejected authorization ID data update.
@@ -677,7 +677,7 @@ extension SwiftDelegate: SwiftBridgeDelegate {
         
         self.store.send(.appDelegateAction(.appLifecycleEvent(.willEnterForeground)))
         self.store.send(vpnAction: .syncWithProvider(reason: .appEnteredForeground))
-        self.store.send(.psiCash(.refreshPsiCashState))
+        self.store.send(.psiCash(.refreshPsiCashState()))
     }
     
     @objc func applicationDidEnterBackground(_ application: UIApplication) {


### PR DESCRIPTION
Motivation:
With the addition of PsiCash accounts the balance displayed
when PsiCashViewController is opened from settings can be incorrect,
since PsiCash refresh state is ignored for subscribed users.

Modifications:
Forces PsiCash refresh state for subscribed users when the
PsiCash screen is presented.