### PR TITLE
Explicitly defined AppState fields to be included in feedback

### DIFF
--- a/PsiApi/Sources/PsiCashClient/PsiCashState.swift
+++ b/PsiApi/Sources/PsiCashClient/PsiCashState.swift
@@ -57,6 +57,16 @@ public struct PsiCashState: Equatable {
     
 }
 
+extension PsiCashState: CustomFieldFeedbackDescription {
+    public var feedbackFields: [String : CustomStringConvertible] {
+        [
+            "purchasing": String(describing: purchasing),
+            "pendingAccountLoginLogout": String(describing: pendingAccountLoginLogout),
+            "pendingPsiCashRefresh": String(describing: pendingPsiCashRefresh)
+        ]
+    }
+}
+
 extension PsiCashState {
     
     public init() {

--- a/Psiphon/AppState+Feedback.swift
+++ b/Psiphon/AppState+Feedback.swift
@@ -24,19 +24,26 @@ import ReactiveSwift
 extension AppState {
 
     /// `feedbackEntry` returns a diagnostic entry which captures the current app state for logging.
-    func feedbackEntry<Value, Action>(userDefaultsConfig: UserDefaultsConfig,
-                                      sharedDB: PsiphonDataSharedDB,
-                                      store: Store<Value, Action>) -> DiagnosticEntry {
+    func feedbackEntry<Value, Action>(
+        userDefaultsConfig: UserDefaultsConfig,
+        sharedDB: PsiphonDataSharedDB,
+        store: Store<Value, Action>,
+        psiCashLib: PsiCashLib
+    ) -> DiagnosticEntry {
+        
+
         let msg =
             """
             ContainerInfo: {
             \"AppState\":\"\(makeFeedbackEntry(self))\",
+            \"PsiCashLib\":\"\(psiCashLib.getDiagnosticInfo())\",
             \"UserDefaultsConfig\":\"\(makeFeedbackEntry(UserDefaultsConfig()))\",
             \"PsiphonDataSharedDB\": \"\(makeFeedbackEntry(sharedDB))\",
             \"OutstandingEffectCount\": \(store.outstandingEffectCount)
             }
             """
         return DiagnosticEntry(msg, andTimestamp: .some(Date()))
+        
     }
 
 }

--- a/Psiphon/AppState.swift
+++ b/Psiphon/AppState.swift
@@ -47,6 +47,27 @@ struct AppState: Equatable {
     var mainView = MainViewState()
 }
 
+// Fields that are added to the
+extension AppState: CustomFieldFeedbackDescription {
+    var feedbackFields: [String : CustomStringConvertible] {
+        [
+            "vpnState": String(describing: vpnState),
+            "psiCashBalance": String(describing: psiCashBalance),
+            "psiCashState": String(describing: psiCashState),
+            "appReceipt": String(describing: appReceipt),
+            "subscription": String(describing: subscription),
+            "subscriptionAuthState": String(describing: subscriptionAuthState),
+            "iapState": String(describing: iapState),
+            "products": String(describing: products),
+            "pendingLandingPageOpening": String(describing: pendingLandingPageOpening),
+            "internetReachability": String(describing: internetReachability),
+            "appDelegateState": String(describing: appDelegateState),
+            "queuedFeedbacks": String(describing: queuedFeedbacks),
+            "mainView": String(describing: mainView),
+        ]
+    }
+}
+
 extension AppState {
     
     /// True if unknown values of `AppState` have been initialized.
@@ -339,7 +360,8 @@ func makeEnvironment(
             .map { appState -> DiagnosticEntry in
                 return appState.feedbackEntry(userDefaultsConfig: userDefaultsConfig,
                                               sharedDB: sharedDB,
-                                              store: store)
+                                              store: store,
+                                              psiCashLib: psiCashLib)
             },
         getFeedbackUpload: { PsiphonTunnelFeedback() },
         getTopPresentedViewController: getTopPresentedViewController,

--- a/Psiphon/PsiCash/PsiCashLib.swift
+++ b/Psiphon/PsiCash/PsiCashLib.swift
@@ -628,6 +628,11 @@ final class PsiCashLib {
         
     }
     
+    /// Exposes PsiCash library `getDiagnosticInfo` function.
+    func getDiagnosticInfo() -> String {
+        self.client.getDiagnosticInfo()
+    }
+    
 }
 
 // MARK: Map ObjC types to equivalent Swift types

--- a/Psiphon/Types+FeedbackDescription.swift
+++ b/Psiphon/Types+FeedbackDescription.swift
@@ -21,8 +21,6 @@ import Foundation
 import PsiApi
 import AppStoreIAP
 
-extension AppState: FeedbackDescription {}
-
 extension TunnelProviderVPNStatus: CustomStringFeedbackDescription {
     
     public var description: String {


### PR DESCRIPTION
To mitigate the risk of accidentally leaking PII, AppState fields
should be explicitly added to feedback logs.

Modifications:
- Explicitly defined AppState fields that are included in feedback
- Removed "PsiCashLibData" struct from feedback
- Added PsiCash library diagnostic info to the feedback