### PR TITLE
Psicash accounts fixes

### DIFF
--- a/PsiApi/Sources/AppStoreIAP/IAPReducer.swift
+++ b/PsiApi/Sources/AppStoreIAP/IAPReducer.swift
@@ -371,8 +371,7 @@ public let iapReducer = Reducer<IAPReducerState, IAPAction, IAPEnvironment> {
                     case .clientError = responseMetadata.statusCode.responseType
                 {
                     
-                    effects += environment.psiCashStore(
-                        .refreshPsiCashState(ignoreSubscriptionState: false))
+                    effects += environment.psiCashStore(.refreshPsiCashState())
                         .mapNever()
                     
                 }

--- a/PsiApi/Sources/PsiCashClient/PsiCashReducerActions.swift
+++ b/PsiApi/Sources/PsiCashClient/PsiCashReducerActions.swift
@@ -49,7 +49,6 @@ public enum PsiCashAction: Equatable {
     
     case userDidEarnReward(PsiCashAmount, PsiCashBalance.BalanceOutOfDateReason)
     
-    case connectToPsiphonTapped
     case dismissedAlert(PsiCashAlertDismissAction)
     
     /// Represents result of syncing authorizations with Core Data.

--- a/PsiApi/Sources/PsiCashClient/PsiCashReducerActions.swift
+++ b/PsiApi/Sources/PsiCashClient/PsiCashReducerActions.swift
@@ -36,9 +36,9 @@ public enum PsiCashAction: Equatable {
             result: NewExpiringPurchaseResult
          )
     
-    /// PsiCash RefreshState. If `ignoreSubscriptionState` is true, RefreshState action
-    /// is not taken if the user is subscribed.
-    case refreshPsiCashState(ignoreSubscriptionState: Bool = false)
+    /// Performs a PsiCash RefreshState.
+    ///  If `forced` is true, RefreshState action is taken whether or not the user is subscribed.
+    case refreshPsiCashState(forced: Bool = false)
     case _refreshPsiCashStateResult(PsiCashEffectsProtocol.PsiCashRefreshResult)
     
     case accountLogout

--- a/Psiphon.xcodeproj/project.pbxproj
+++ b/Psiphon.xcodeproj/project.pbxproj
@@ -104,7 +104,7 @@
 		52A2465E239081C100A01FF1 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52A2465D239081C100A01FF1 /* AppState.swift */; };
 		52A24662239B07E000A01FF1 /* psiCashProductIds.plist in Resources */ = {isa = PBXBuildFile; fileRef = 52A24661239B07E000A01FF1 /* psiCashProductIds.plist */; };
 		52A2466D23A172A800A01FF1 /* ViewBuilderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52A2466C23A172A800A01FF1 /* ViewBuilderViewController.swift */; };
-		52A2466F23A1769300A01FF1 /* PsiCashMessageViewUntunneled.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52A2466E23A1769300A01FF1 /* PsiCashMessageViewUntunneled.swift */; };
+		52A2466F23A1769300A01FF1 /* PsiCashMessageViewWithButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52A2466E23A1769300A01FF1 /* PsiCashMessageViewWithButton.swift */; };
 		52A2467123A176BA00A01FF1 /* PurchasingAlertViewBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52A2467023A176BA00A01FF1 /* PurchasingAlertViewBuilder.swift */; };
 		52B3C54A23DF99E8003F6B12 /* AppObservables.m in Sources */ = {isa = PBXBuildFile; fileRef = 52B3C54923DF99E8003F6B12 /* AppObservables.m */; };
 		52B3C54C23E0E895003F6B12 /* ButtonBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B3C54B23E0E895003F6B12 /* ButtonBuilder.swift */; };
@@ -552,7 +552,7 @@
 		52A2465D239081C100A01FF1 /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
 		52A24661239B07E000A01FF1 /* psiCashProductIds.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = psiCashProductIds.plist; sourceTree = "<group>"; };
 		52A2466C23A172A800A01FF1 /* ViewBuilderViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewBuilderViewController.swift; sourceTree = "<group>"; };
-		52A2466E23A1769300A01FF1 /* PsiCashMessageViewUntunneled.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PsiCashMessageViewUntunneled.swift; sourceTree = "<group>"; };
+		52A2466E23A1769300A01FF1 /* PsiCashMessageViewWithButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PsiCashMessageViewWithButton.swift; sourceTree = "<group>"; };
 		52A2467023A176BA00A01FF1 /* PurchasingAlertViewBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchasingAlertViewBuilder.swift; sourceTree = "<group>"; };
 		52B3C54823DF99E8003F6B12 /* AppObservables.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppObservables.h; sourceTree = "<group>"; };
 		52B3C54923DF99E8003F6B12 /* AppObservables.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppObservables.m; sourceTree = "<group>"; };
@@ -1259,7 +1259,7 @@
 				52C8F0AC237E145C00E5F9C0 /* PsiCashCoinPurchaseTable.swift */,
 				528D81322384823F00AA2D77 /* PsiCashMessageView.swift */,
 				52A24658238C9AB700A01FF1 /* SpeedBoostPurchaseTable.swift */,
-				52A2466E23A1769300A01FF1 /* PsiCashMessageViewUntunneled.swift */,
+				52A2466E23A1769300A01FF1 /* PsiCashMessageViewWithButton.swift */,
 				52A2467023A176BA00A01FF1 /* PurchasingAlertViewBuilder.swift */,
 				8DB6C6352429080C005E2F4C /* PsiCashMessageWithRetryView.swift */,
 				8D335A51251A929E005F62CA /* PsiCashAccountSignupOrLoginView.swift */,
@@ -2101,7 +2101,7 @@
 				EF90D7A1204F22C900228A63 /* timestamp_valid.c in Sources */,
 				445F24DF20E1A5BA00D004E9 /* ANY.c in Sources */,
 				296622B525E8A554004635A1 /* LaunchScreenViewController.swift in Sources */,
-				52A2466F23A1769300A01FF1 /* PsiCashMessageViewUntunneled.swift in Sources */,
+				52A2466F23A1769300A01FF1 /* PsiCashMessageViewWithButton.swift in Sources */,
 				8D0017D924DB4B1200EC3409 /* OnboardingViewController.swift in Sources */,
 				EFC2F5C420226782007B52F9 /* RootContainerController.m in Sources */,
 				EF90D7A5204F22C900228A63 /* timestamp_parse.c in Sources */,

--- a/Psiphon/AppState.swift
+++ b/Psiphon/AppState.swift
@@ -386,6 +386,7 @@ func makeEnvironment(
                 dateCompare: dateCompare,
                 feedbackLogger: feedbackLogger,
                 tunnelConnectionRefSignal: store.$value.signalProducer.map(\.tunnelConnection),
+                objCBridgeDelegate: objcBridgeDelegate,
                 onDismissed: { [unowned store] in
                     store.send(.mainViewAction(.dismissedPsiCashScreen))
                 }

--- a/Psiphon/PsiCash/PsiCashReducer.swift
+++ b/Psiphon/PsiCash/PsiCashReducer.swift
@@ -490,15 +490,6 @@ let psiCashReducer = Reducer<PsiCashReducerState, PsiCashAction, PsiCashEnvironm
         
         return [ Effect(value: .refreshPsiCashState()) ]
         
-    case .connectToPsiphonTapped:
-        return [
-            .fireAndForget { [unowned objcBridgeDelegate = environment.objcBridgeDelegate] in
-                objcBridgeDelegate?.dismiss(screen: .psiCash, completion: {
-                    objcBridgeDelegate?.startStopVPN()
-                })
-            }
-        ]
-        
     case ._coreDataSyncResult(let syncResult):
         
         // Notifies the Network Extension of any changes to persisted authorization in Core Data.

--- a/Psiphon/PsiCash/PsiCashReducer.swift
+++ b/Psiphon/PsiCash/PsiCashReducer.swift
@@ -134,7 +134,9 @@ let psiCashReducer = Reducer<PsiCashReducerState, PsiCashAction, PsiCashEnvironm
         
         return [
             environment.psiCashEffects.setLocale(locale)
-                .mapNever()
+                .mapNever(),
+            
+            Effect(value: .refreshPsiCashState())
         ]
         
     case .buyPsiCashProduct(let purchasableType):
@@ -254,7 +256,7 @@ let psiCashReducer = Reducer<PsiCashReducerState, PsiCashAction, PsiCashEnvironm
                     .requestError(.errorStatus(.transactionTypeNotFound)),
                     .requestError(.errorStatus(.invalidTokens)):
                 
-                effects += Effect(value: .refreshPsiCashState(ignoreSubscriptionState: false))
+                effects += Effect(value: .refreshPsiCashState())
                 
             case .tunnelNotConnected,
                     .requestError(.errorStatus(.existingTransaction)),
@@ -452,22 +454,22 @@ let psiCashReducer = Reducer<PsiCashReducerState, PsiCashAction, PsiCashEnvironm
         
         state.psiCash.libData = environment.psiCashEffects.libData()
         
+        var effects = [Effect<PsiCashAction>]()
+        
+        // Refresh PsiCash state (regardless of whether login was successful or not.)
+        effects += Effect(value: .refreshPsiCashState())
+        
         switch result {
         case .success(let accountLoginResponse):
-            return [
-                // Refreshes PsiCash state immediately after successful login.
-                Effect(value: .refreshPsiCashState()),
-                
-                environment.feedbackLogger.log(
-                    .info, "account login completed: '\(accountLoginResponse)'"
-                ).mapNever()
-            ]
+            effects += environment.feedbackLogger.log(
+                .info, "account login completed: '\(accountLoginResponse)'"
+            ).mapNever()
             
         case .failure(let errorEvent):
-            return [
-                environment.feedbackLogger.log(.error, errorEvent).mapNever()
-            ]
+            effects += environment.feedbackLogger.log(.error, errorEvent).mapNever()
         }
+        
+        return effects
         
     case .dismissedAlert(let dismissed):
         switch dismissed {

--- a/Psiphon/UserStrings.swift
+++ b/Psiphon/UserStrings.swift
@@ -471,6 +471,12 @@ extension UserStrings {
                                  value: "Please try again later.",
                                  comment: "Subtitle shown when the current operation failed, asking the user to try again at a later time.")
     }
+    
+    static func Something_went_wrong_try_agaig_and_send_feedback() -> String {
+        return NSLocalizedString("PLEASE_TRY_AGAIN_LATER_AND_SEND_FEEDBACK", tableName: nil, bundle: Bundle.main,
+                                 value: "Something went wrong, please try again later.\n\nIf this problem persists, please send a feedback.",
+                                 comment: "Subtitle of an error message shown when the current operation failed, asking the user to try again at a later time and send us a feedback if this problem persists.")
+    }
 
     static func Purchase_failed() -> String {
         return NSLocalizedString("GENERIC_PURCHASE_FAILED", tableName: nil, bundle: Bundle.main,

--- a/Psiphon/View/PsiCashView/PsiCashMessageView.swift
+++ b/Psiphon/View/PsiCashView/PsiCashMessageView.swift
@@ -31,6 +31,7 @@ struct PsiCashMessageView: ViewBuilder {
         case signupOrLoginToPsiCash
         case psiCashAccountsLoggingIn
         case psiCashAccountsLoggingOut
+        case noSpeedBoostProducts
     }
 
     func build(_ container: UIView?) -> ImmutableBindableViewable<Message, UIView> {
@@ -134,6 +135,12 @@ struct PsiCashMessageView: ViewBuilder {
                     imageView.image = UIImage(named: "PsiCashCoinCloud")!
                     title.text = UserStrings.Logging_out_ellipses()
                     subtitle.text = ""
+                
+                case .noSpeedBoostProducts:
+                    imageView.image = UIImage(named: "PsiCashCoinCloud")!
+                    title.text = UserStrings.PsiCash_unavailable()
+                    subtitle.text = UserStrings.Something_went_wrong_try_agaig_and_send_feedback()
+                    subtitle.textAlignment = .center
                     
                 }
             }

--- a/Psiphon/ViewControllers/PsiCashAccountViewController.swift
+++ b/Psiphon/ViewControllers/PsiCashAccountViewController.swift
@@ -593,7 +593,7 @@ final class PsiCashAccountViewController: ReactiveViewController {
                 // PsiCash RefreshState after dismissal of Account Management screen.
                 // This is necessary since the user might have updated their username, or
                 // other account information.
-                self.store.send(.psiCashAction(.refreshPsiCashState(ignoreSubscriptionState: true)))
+                self.store.send(.psiCashAction(.refreshPsiCashState(forced: true)))
                 
                 let _ = self.display(screenToPresent: .mainScreen)
             }

--- a/Psiphon/ViewControllers/WebViewController.swift
+++ b/Psiphon/ViewControllers/WebViewController.swift
@@ -22,6 +22,7 @@ import WebKit
 import PsiApi
 import Utilities
 import ReactiveSwift
+import SafariServices
 
 fileprivate enum WebViewFailure: HashableError {
     case didFail(SystemError<Int>)
@@ -252,6 +253,27 @@ extension WebViewController: WKUIDelegate {
     
     func webViewDidClose(_ webView: WKWebView) {
         self.dismiss(animated: true, completion: nil)
+    }
+    
+    func webView(
+        _ webView: WKWebView,
+        createWebViewWith configuration: WKWebViewConfiguration,
+        for navigationAction: WKNavigationAction,
+        windowFeatures: WKWindowFeatures
+    ) -> WKWebView? {
+        
+        // Opens target="_blank" links in an SFSafariViewController,
+        // presented on top of the current view controller.
+        
+        guard let url = navigationAction.request.url else {
+            return nil
+        }
+        
+        let safari = SFSafariViewController(url: url)
+        self.present(safari, animated: true, completion: nil)
+        
+        return nil
+        
     }
     
 }

--- a/Shared/Strings/am.lproj/Localizable.strings
+++ b/Shared/Strings/am.lproj/Localizable.strings
@@ -142,8 +142,8 @@
 /*[UNTRANSLATED] Do not translate or transliterate 'PsiCash'. Informs the user that they must sign up for a PsiCash account or log in to their PsiCash account in order to user PsiCash features. */
 "LOG_IN_OR_SIGNUP_TO_CONTINUE" = "Log in or create account to continue using PsiCash";
 
-/* Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
-"LOG_OUT_ANY_WAY_BUTTON_TITLE" = "Logout anyway";
+/*[UNTRANSLATED] Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
+"LOG_OUT_ANY_WAY_BUTTON_TITLE_2" = "Log out anyway";
 
 /*[UNTRANSLATED] Title of the button that lets users log out of their account */
 "LOG_OUT_BUTTON_TITLE_2" = "Log out";
@@ -346,7 +346,7 @@
 /* Message when the user has made a purchase, and paid successfully, however the transaction is not complete yet and is pending verification */
 "PSICASH_WAIT_TRANSACTION_VERIFIED" = "ግብይትዎ እስኪረጋገጥ ድረስ እባክዎትን ትንሽ ይጠብቁ";
 
-/* Alert message informing user that a Psip */
+/* Alert message informing user that a Psiphon connection is required */
 "PSIPHON_CONNECTION_REQUIRED" = "Psiphon ግንኙነት ያስፈልጋል";
 
 /* Shown when user is not connected to Psiphon network. Do not translate or transliterate 'Psiphon' */
@@ -403,31 +403,31 @@
 /* Do not transliterate 'Speed Boost'. 'Speed Boost' is a reward that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */
 "SPEED_BOOST" = "ፍጥነት ጭማሬ";
 
-/* Label on a button. Clicking this button will buy 1 hour of Speed Boost. */
+/* Label on a button. Clicking this button will buy 1 hour of Speed Boost. Translate number as well. */
 "SPEED_BOOST_1HR" = "1 ሰዓት";
 
-/* Label on a button. Clicking this button will buy 2 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 2 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_2HR" = "2 ሰዓት";
 
-/* Label on a button. Clicking this button will buy 3 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 3 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_3HR" = "3 ሰዓት";
 
-/* Label on a button. Clicking this button will buy 4 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 4 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_4HR" = "4 ሰዓት";
 
-/* Label on a button. Clicking this button will buy 5 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 5 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_5HR" = "5 ሰዓት";
 
-/* Label on a button. Clicking this button will buy 6 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 6 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_6HR" = "6 ሰዓት";
 
-/* Label on a button. Clicking this button will buy 7 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 7 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_7HR" = "7 ሰዓት";
 
-/* Label on a button. Clicking this button will buy 8 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 8 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_8HR" = "8 ሰዓት";
 
-/* Label on a button. Clicking this button will buy 9 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 9 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_9HR" = "9 ሰዓት";
 
 /* Do not transliterate 'Speed Boost'. 'Speed Boost' is a product that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */

--- a/Shared/Strings/ar.lproj/Localizable.strings
+++ b/Shared/Strings/ar.lproj/Localizable.strings
@@ -142,8 +142,8 @@
 /*[UNTRANSLATED] Do not translate or transliterate 'PsiCash'. Informs the user that they must sign up for a PsiCash account or log in to their PsiCash account in order to user PsiCash features. */
 "LOG_IN_OR_SIGNUP_TO_CONTINUE" = "Log in or create account to continue using PsiCash";
 
-/* Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
-"LOG_OUT_ANY_WAY_BUTTON_TITLE" = "Logout anyway";
+/*[UNTRANSLATED] Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
+"LOG_OUT_ANY_WAY_BUTTON_TITLE_2" = "Log out anyway";
 
 /* Title of the button that lets users log out of their account */
 "LOG_OUT_BUTTON_TITLE_2" = "تسجيل الخروج";
@@ -346,7 +346,7 @@
 /* Message when the user has made a purchase, and paid successfully, however the transaction is not complete yet and is pending verification */
 "PSICASH_WAIT_TRANSACTION_VERIFIED" = "يُرجى الانتظار ريثما يتم التحقق من معاملتك";
 
-/* Alert message informing user that a Psip */
+/* Alert message informing user that a Psiphon connection is required */
 "PSIPHON_CONNECTION_REQUIRED" = "يلزم الاتصال ب Psiphon";
 
 /* Shown when user is not connected to Psiphon network. Do not translate or transliterate 'Psiphon' */
@@ -403,31 +403,31 @@
 /* Do not transliterate 'Speed Boost'. 'Speed Boost' is a reward that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */
 "SPEED_BOOST" = "تعزيز السرعة";
 
-/* Label on a button. Clicking this button will buy 1 hour of Speed Boost. */
+/* Label on a button. Clicking this button will buy 1 hour of Speed Boost. Translate number as well. */
 "SPEED_BOOST_1HR" = "ساعة";
 
-/* Label on a button. Clicking this button will buy 2 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 2 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_2HR" = "ساعتين";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_3HR" = "3 hours";
 
-/* Label on a button. Clicking this button will buy 4 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 4 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_4HR" = "4 ساعات";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_5HR" = "5 hours";
 
-/* Label on a button. Clicking this button will buy 6 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 6 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_6HR" = "6 ساعات";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_7HR" = "7 hours";
 
-/* Label on a button. Clicking this button will buy 8 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 8 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_8HR" = "8 ساعات";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_9HR" = "9 hours";
 
 /* Do not transliterate 'Speed Boost'. 'Speed Boost' is a product that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */

--- a/Shared/Strings/az.lproj/Localizable.strings
+++ b/Shared/Strings/az.lproj/Localizable.strings
@@ -142,8 +142,8 @@
 /*[UNTRANSLATED] Do not translate or transliterate 'PsiCash'. Informs the user that they must sign up for a PsiCash account or log in to their PsiCash account in order to user PsiCash features. */
 "LOG_IN_OR_SIGNUP_TO_CONTINUE" = "Log in or create account to continue using PsiCash";
 
-/* Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
-"LOG_OUT_ANY_WAY_BUTTON_TITLE" = "Logout anyway";
+/*[UNTRANSLATED] Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
+"LOG_OUT_ANY_WAY_BUTTON_TITLE_2" = "Log out anyway";
 
 /*[UNTRANSLATED] Title of the button that lets users log out of their account */
 "LOG_OUT_BUTTON_TITLE_2" = "Log out";
@@ -346,7 +346,7 @@
 /*[UNTRANSLATED] Message when the user has made a purchase, and paid successfully, however the transaction is not complete yet and is pending verification */
 "PSICASH_WAIT_TRANSACTION_VERIFIED" = "Please wait while your transaction is being verified";
 
-/*[UNTRANSLATED] Alert message informing user that a Psip */
+/*[UNTRANSLATED] Alert message informing user that a Psiphon connection is required */
 "PSIPHON_CONNECTION_REQUIRED" = "Psiphon Connection Required";
 
 /*[UNTRANSLATED] Shown when user is not connected to Psiphon network. Do not translate or transliterate 'Psiphon' */
@@ -403,31 +403,31 @@
 /*[UNTRANSLATED] Do not transliterate 'Speed Boost'. 'Speed Boost' is a reward that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */
 "SPEED_BOOST" = "Speed Boost";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 1 hour of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 1 hour of Speed Boost. Translate number as well. */
 "SPEED_BOOST_1HR" = "1 hour";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 2 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 2 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_2HR" = "2 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_3HR" = "3 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 4 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 4 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_4HR" = "4 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_5HR" = "5 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 6 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 6 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_6HR" = "6 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_7HR" = "7 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 8 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 8 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_8HR" = "8 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_9HR" = "9 hours";
 
 /*[UNTRANSLATED] Do not transliterate 'Speed Boost'. 'Speed Boost' is a product that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */

--- a/Shared/Strings/be.lproj/Localizable.strings
+++ b/Shared/Strings/be.lproj/Localizable.strings
@@ -19,8 +19,8 @@
 /* Title of the button which takes the user to the previous screen. Text should be short and one word when possible. */
 "BACK_BUTTON" = "Назад";
 
-/*[UNTRANSLATED] Title of button on alert view which shows the progress of the user's buy request. Hitting this button dismisses the alert and the buy request continues processing in the background. */
-"BUY_REQUEST_PROGRESS_ALERT_DISMISS_BUTTON_TITLE" = "Dismiss";
+/* Title of button on alert view which shows the progress of the user's buy request. Hitting this button dismisses the alert and the buy request continues processing in the background. */
+"BUY_REQUEST_PROGRESS_ALERT_DISMISS_BUTTON_TITLE" = "Адхіліць";
 
 /*[UNTRANSLATED] Buy subscription dialog footer text explaining where the user can cancel an active subscription */
 "BUY_SUBSCRIPTIONS_FOOTER_CANCEL_INSTRUCTIONS_TEXT" = "You can cancel an active subscription in your iTunes Account Settings.";
@@ -91,8 +91,8 @@
 /*[UNTRANSLATED] Text next to the button indicating to the user that the rewarded video advertisement is only available when they are not connected to Psiphon. Do not translate or transliterate 'PsiCash'. Do not translate or transliterate 'Psiphon'. */
 "DISCONNECT_TO_WATCH_AND_EARN_PSICASH" = "You must disconnect from Psiphon to watch a video to earn PsiCash";
 
-/*[UNTRANSLATED] Dismiss button title. Dismisses pop-up alert when the user clicks on the button */
-"DISMISS_BUTTON_TITLE" = "Dismiss";
+/* Dismiss button title. Dismisses pop-up alert when the user clicks on the button */
+"DISMISS_BUTTON_TITLE" = "Адхіліць";
 
 /* Title of the button that dismisses a screen or a dialog */
 "DONE_BUTTON_TITLE" = "Гатова";
@@ -133,8 +133,8 @@
 /*[UNTRANSLATED] Message shown when a resource (online or offline) fails to load. */
 "LOADING_FAILED" = "Loading failed";
 
-/*[UNTRANSLATED] Title on a button that lets users login to their account with the username and password they have entered. */
-"LOG_IN_BUTTON_TITLE" = "Log in";
+/* Title on a button that lets users login to their account with the username and password they have entered. */
+"LOG_IN_BUTTON_TITLE" = "Увайсці";
 
 /*[UNTRANSLATED] Message title informing the user that they must sign up for an account or log in to their account */
 "LOG_IN_OR_SIGN_UP" = "Log in or sign up";
@@ -142,8 +142,8 @@
 /*[UNTRANSLATED] Do not translate or transliterate 'PsiCash'. Informs the user that they must sign up for a PsiCash account or log in to their PsiCash account in order to user PsiCash features. */
 "LOG_IN_OR_SIGNUP_TO_CONTINUE" = "Log in or create account to continue using PsiCash";
 
-/* Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
-"LOG_OUT_ANY_WAY_BUTTON_TITLE" = "Logout anyway";
+/*[UNTRANSLATED] Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
+"LOG_OUT_ANY_WAY_BUTTON_TITLE_2" = "Log out anyway";
 
 /* Title of the button that lets users log out of their account */
 "LOG_OUT_BUTTON_TITLE_2" = "Выхад";
@@ -346,7 +346,7 @@
 /*[UNTRANSLATED] Message when the user has made a purchase, and paid successfully, however the transaction is not complete yet and is pending verification */
 "PSICASH_WAIT_TRANSACTION_VERIFIED" = "Please wait while your transaction is being verified";
 
-/*[UNTRANSLATED] Alert message informing user that a Psip */
+/*[UNTRANSLATED] Alert message informing user that a Psiphon connection is required */
 "PSIPHON_CONNECTION_REQUIRED" = "Psiphon Connection Required";
 
 /*[UNTRANSLATED] Shown when user is not connected to Psiphon network. Do not translate or transliterate 'Psiphon' */
@@ -403,31 +403,31 @@
 /*[UNTRANSLATED] Do not transliterate 'Speed Boost'. 'Speed Boost' is a reward that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */
 "SPEED_BOOST" = "Speed Boost";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 1 hour of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 1 hour of Speed Boost. Translate number as well. */
 "SPEED_BOOST_1HR" = "1 hour";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 2 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 2 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_2HR" = "2 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_3HR" = "3 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 4 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 4 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_4HR" = "4 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_5HR" = "5 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 6 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 6 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_6HR" = "6 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_7HR" = "7 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 8 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 8 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_8HR" = "8 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_9HR" = "9 hours";
 
 /*[UNTRANSLATED] Do not transliterate 'Speed Boost'. 'Speed Boost' is a product that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */

--- a/Shared/Strings/bn.lproj/Localizable.strings
+++ b/Shared/Strings/bn.lproj/Localizable.strings
@@ -142,8 +142,8 @@
 /*[UNTRANSLATED] Do not translate or transliterate 'PsiCash'. Informs the user that they must sign up for a PsiCash account or log in to their PsiCash account in order to user PsiCash features. */
 "LOG_IN_OR_SIGNUP_TO_CONTINUE" = "Log in or create account to continue using PsiCash";
 
-/* Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
-"LOG_OUT_ANY_WAY_BUTTON_TITLE" = "Logout anyway";
+/*[UNTRANSLATED] Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
+"LOG_OUT_ANY_WAY_BUTTON_TITLE_2" = "Log out anyway";
 
 /*[UNTRANSLATED] Title of the button that lets users log out of their account */
 "LOG_OUT_BUTTON_TITLE_2" = "Log out";
@@ -346,7 +346,7 @@
 /*[UNTRANSLATED] Message when the user has made a purchase, and paid successfully, however the transaction is not complete yet and is pending verification */
 "PSICASH_WAIT_TRANSACTION_VERIFIED" = "Please wait while your transaction is being verified";
 
-/*[UNTRANSLATED] Alert message informing user that a Psip */
+/*[UNTRANSLATED] Alert message informing user that a Psiphon connection is required */
 "PSIPHON_CONNECTION_REQUIRED" = "Psiphon Connection Required";
 
 /*[UNTRANSLATED] Shown when user is not connected to Psiphon network. Do not translate or transliterate 'Psiphon' */
@@ -403,31 +403,31 @@
 /*[UNTRANSLATED] Do not transliterate 'Speed Boost'. 'Speed Boost' is a reward that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */
 "SPEED_BOOST" = "Speed Boost";
 
-/* Label on a button. Clicking this button will buy 1 hour of Speed Boost. */
+/* Label on a button. Clicking this button will buy 1 hour of Speed Boost. Translate number as well. */
 "SPEED_BOOST_1HR" = "1 ঘন্টা";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 2 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 2 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_2HR" = "2 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_3HR" = "3 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 4 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 4 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_4HR" = "4 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_5HR" = "5 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 6 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 6 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_6HR" = "6 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_7HR" = "7 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 8 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 8 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_8HR" = "8 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_9HR" = "9 hours";
 
 /*[UNTRANSLATED] Do not transliterate 'Speed Boost'. 'Speed Boost' is a product that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */

--- a/Shared/Strings/bo.lproj/Localizable.strings
+++ b/Shared/Strings/bo.lproj/Localizable.strings
@@ -142,8 +142,8 @@
 /*[UNTRANSLATED] Do not translate or transliterate 'PsiCash'. Informs the user that they must sign up for a PsiCash account or log in to their PsiCash account in order to user PsiCash features. */
 "LOG_IN_OR_SIGNUP_TO_CONTINUE" = "Log in or create account to continue using PsiCash";
 
-/* Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
-"LOG_OUT_ANY_WAY_BUTTON_TITLE" = "Logout anyway";
+/*[UNTRANSLATED] Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
+"LOG_OUT_ANY_WAY_BUTTON_TITLE_2" = "Log out anyway";
 
 /*[UNTRANSLATED] Title of the button that lets users log out of their account */
 "LOG_OUT_BUTTON_TITLE_2" = "Log out";
@@ -346,7 +346,7 @@
 /*[UNTRANSLATED] Message when the user has made a purchase, and paid successfully, however the transaction is not complete yet and is pending verification */
 "PSICASH_WAIT_TRANSACTION_VERIFIED" = "Please wait while your transaction is being verified";
 
-/*[UNTRANSLATED] Alert message informing user that a Psip */
+/*[UNTRANSLATED] Alert message informing user that a Psiphon connection is required */
 "PSIPHON_CONNECTION_REQUIRED" = "Psiphon Connection Required";
 
 /*[UNTRANSLATED] Shown when user is not connected to Psiphon network. Do not translate or transliterate 'Psiphon' */
@@ -403,31 +403,31 @@
 /*[UNTRANSLATED] Do not transliterate 'Speed Boost'. 'Speed Boost' is a reward that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */
 "SPEED_BOOST" = "Speed Boost";
 
-/* Label on a button. Clicking this button will buy 1 hour of Speed Boost. */
+/* Label on a button. Clicking this button will buy 1 hour of Speed Boost. Translate number as well. */
 "SPEED_BOOST_1HR" = "ཆུ་ཚོད་༡";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 2 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 2 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_2HR" = "2 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_3HR" = "3 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 4 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 4 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_4HR" = "4 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_5HR" = "5 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 6 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 6 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_6HR" = "6 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_7HR" = "7 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 8 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 8 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_8HR" = "8 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_9HR" = "9 hours";
 
 /*[UNTRANSLATED] Do not transliterate 'Speed Boost'. 'Speed Boost' is a product that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */

--- a/Shared/Strings/de.lproj/Localizable.strings
+++ b/Shared/Strings/de.lproj/Localizable.strings
@@ -142,8 +142,8 @@
 /*[UNTRANSLATED] Do not translate or transliterate 'PsiCash'. Informs the user that they must sign up for a PsiCash account or log in to their PsiCash account in order to user PsiCash features. */
 "LOG_IN_OR_SIGNUP_TO_CONTINUE" = "Log in or create account to continue using PsiCash";
 
-/* Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
-"LOG_OUT_ANY_WAY_BUTTON_TITLE" = "Logout anyway";
+/*[UNTRANSLATED] Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
+"LOG_OUT_ANY_WAY_BUTTON_TITLE_2" = "Log out anyway";
 
 /* Title of the button that lets users log out of their account */
 "LOG_OUT_BUTTON_TITLE_2" = "Abmelden";
@@ -346,7 +346,7 @@
 /*[UNTRANSLATED] Message when the user has made a purchase, and paid successfully, however the transaction is not complete yet and is pending verification */
 "PSICASH_WAIT_TRANSACTION_VERIFIED" = "Please wait while your transaction is being verified";
 
-/* Alert message informing user that a Psip */
+/* Alert message informing user that a Psiphon connection is required */
 "PSIPHON_CONNECTION_REQUIRED" = "Psiphon-Verbindung erforderlich";
 
 /* Shown when user is not connected to Psiphon network. Do not translate or transliterate 'Psiphon' */
@@ -403,31 +403,31 @@
 /*[UNTRANSLATED] Do not transliterate 'Speed Boost'. 'Speed Boost' is a reward that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */
 "SPEED_BOOST" = "Speed Boost";
 
-/* Label on a button. Clicking this button will buy 1 hour of Speed Boost. */
+/* Label on a button. Clicking this button will buy 1 hour of Speed Boost. Translate number as well. */
 "SPEED_BOOST_1HR" = "1 Stunde";
 
-/* Label on a button. Clicking this button will buy 2 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 2 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_2HR" = "2 Stunden";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_3HR" = "3 hours";
 
-/* Label on a button. Clicking this button will buy 4 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 4 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_4HR" = "4 Stunden";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_5HR" = "5 hours";
 
-/* Label on a button. Clicking this button will buy 6 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 6 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_6HR" = "6 Stunden";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_7HR" = "7 hours";
 
-/* Label on a button. Clicking this button will buy 8 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 8 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_8HR" = "8 Stunden";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_9HR" = "9 hours";
 
 /*[UNTRANSLATED] Do not transliterate 'Speed Boost'. 'Speed Boost' is a product that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */

--- a/Shared/Strings/el.lproj/Localizable.strings
+++ b/Shared/Strings/el.lproj/Localizable.strings
@@ -142,8 +142,8 @@
 /*[UNTRANSLATED] Do not translate or transliterate 'PsiCash'. Informs the user that they must sign up for a PsiCash account or log in to their PsiCash account in order to user PsiCash features. */
 "LOG_IN_OR_SIGNUP_TO_CONTINUE" = "Log in or create account to continue using PsiCash";
 
-/* Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
-"LOG_OUT_ANY_WAY_BUTTON_TITLE" = "Logout anyway";
+/*[UNTRANSLATED] Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
+"LOG_OUT_ANY_WAY_BUTTON_TITLE_2" = "Log out anyway";
 
 /*[UNTRANSLATED] Title of the button that lets users log out of their account */
 "LOG_OUT_BUTTON_TITLE_2" = "Log out";
@@ -346,7 +346,7 @@
 /*[UNTRANSLATED] Message when the user has made a purchase, and paid successfully, however the transaction is not complete yet and is pending verification */
 "PSICASH_WAIT_TRANSACTION_VERIFIED" = "Please wait while your transaction is being verified";
 
-/*[UNTRANSLATED] Alert message informing user that a Psip */
+/*[UNTRANSLATED] Alert message informing user that a Psiphon connection is required */
 "PSIPHON_CONNECTION_REQUIRED" = "Psiphon Connection Required";
 
 /*[UNTRANSLATED] Shown when user is not connected to Psiphon network. Do not translate or transliterate 'Psiphon' */
@@ -403,31 +403,31 @@
 /*[UNTRANSLATED] Do not transliterate 'Speed Boost'. 'Speed Boost' is a reward that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */
 "SPEED_BOOST" = "Speed Boost";
 
-/* Label on a button. Clicking this button will buy 1 hour of Speed Boost. */
+/* Label on a button. Clicking this button will buy 1 hour of Speed Boost. Translate number as well. */
 "SPEED_BOOST_1HR" = "1 ώρα";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 2 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 2 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_2HR" = "2 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_3HR" = "3 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 4 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 4 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_4HR" = "4 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_5HR" = "5 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 6 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 6 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_6HR" = "6 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_7HR" = "7 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 8 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 8 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_8HR" = "8 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_9HR" = "9 hours";
 
 /*[UNTRANSLATED] Do not transliterate 'Speed Boost'. 'Speed Boost' is a product that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */

--- a/Shared/Strings/en.lproj/Localizable.strings
+++ b/Shared/Strings/en.lproj/Localizable.strings
@@ -201,6 +201,9 @@
 /* Subtitle shown when the current operation failed, asking the user to try again at a later time. */
 "PLEASE_TRY_AGAIN_LATER" = "Please try again later.";
 
+/* Subtitle of an error message shown when the current operation failed, asking the user to try again at a later time and send us a feedback if this problem persists. */
+"PLEASE_TRY_AGAIN_LATER_AND_SEND_FEEDBACK" = "Something went wrong, please try again later.\n\nIf this problem persists, please send a feedback.";
+
 /* Alert message when the user declined privacy policy. They will not be able to use the app until the user accepts the privacy policy (Do not translate 'Psiphon') */
 "PRIVACY_POLICY_DECLINED_ALERT_BODY" = "You must accept our Privacy Policy before continuing to use Psiphon.";
 

--- a/Shared/Strings/es.lproj/Localizable.strings
+++ b/Shared/Strings/es.lproj/Localizable.strings
@@ -55,8 +55,8 @@
 /* User must connect to 'Psiphon' in order to use 'Speed Boost' product. Do not translate or transliterate 'Psiphon'. Do not transliterate 'Speed Boost'. 'Speed Boost' is a reward that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */
 "CONNECT_TO_USE_SPEED_BOOST" = "Conéctate a Psiphon para usar Aumento de Velocidad";
 
-/*[UNTRANSLATED] Label text shown to user when the VPN is connecting to a Psiphon server. Do not translate or transliterate 'Psiphon' */
-"CONNECTING_TO_PSIPHON" = "Connecting to Psiphon";
+/* Label text shown to user when the VPN is connecting to a Psiphon server. Do not translate or transliterate 'Psiphon' */
+"CONNECTING_TO_PSIPHON" = "Conectando a Psiphon";
 
 /* Alert dialog message informing the user that the settings file in the app is corrupt, and that they can potentially fix this issue by re-installing the app. */
 "CORRUPT_SETTINGS_MESSAGE" = "El fichero de configuración de su aplicación parece estar corrupto. Pruebe a reinstalar la aplicación para reparar el fichero.";
@@ -130,29 +130,29 @@
 /* Text displayed while app loads */
 "LOADING" = "Cargando...";
 
-/*[UNTRANSLATED] Message shown when a resource (online or offline) fails to load. */
-"LOADING_FAILED" = "Loading failed";
+/* Message shown when a resource (online or offline) fails to load. */
+"LOADING_FAILED" = "Carga fallida";
 
 /* Title on a button that lets users login to their account with the username and password they have entered. */
 "LOG_IN_BUTTON_TITLE" = "Iniciar sesión";
 
-/*[UNTRANSLATED] Message title informing the user that they must sign up for an account or log in to their account */
-"LOG_IN_OR_SIGN_UP" = "Log in or sign up";
+/* Message title informing the user that they must sign up for an account or log in to their account */
+"LOG_IN_OR_SIGN_UP" = "Iniciar sesión o registrarse";
 
-/*[UNTRANSLATED] Do not translate or transliterate 'PsiCash'. Informs the user that they must sign up for a PsiCash account or log in to their PsiCash account in order to user PsiCash features. */
-"LOG_IN_OR_SIGNUP_TO_CONTINUE" = "Log in or create account to continue using PsiCash";
+/* Do not translate or transliterate 'PsiCash'. Informs the user that they must sign up for a PsiCash account or log in to their PsiCash account in order to user PsiCash features. */
+"LOG_IN_OR_SIGNUP_TO_CONTINUE" = "Inicia sesión o crea una cuenta para continuar usando PsiCash";
 
 /* Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
-"LOG_OUT_ANY_WAY_BUTTON_TITLE" = "Cerrar sesión de cualquier manera";
+"LOG_OUT_ANY_WAY_BUTTON_TITLE_2" = "Cerrar sesión de todos modos";
 
 /* Title of the button that lets users log out of their account */
 "LOG_OUT_BUTTON_TITLE_2" = "Cerrar sesión";
 
-/*[UNTRANSLATED] Label indicating to the user that they are logging into their PsiCash account. Use ellipses if it makes sense. */
-"LOGGING_IN_ELLIPSES" = "Logging in ...";
+/* Label indicating to the user that they are logging into their PsiCash account. Use ellipses if it makes sense. */
+"LOGGING_IN_ELLIPSES" = "Iniciando sesión...";
 
-/*[UNTRANSLATED] Label indicating to the user that they are logging out of their PsiCash account. Use ellipses if it makes sense. */
-"LOGGING_OUT_ELLIPSES" = "Logging out ...";
+/* Label indicating to the user that they are logging out of their PsiCash account. Use ellipses if it makes sense. */
+"LOGGING_OUT_ELLIPSES" = "Cerrando sesión...";
 
 /* Button title that takes user to the next page */
 "NEXT_PAGE_BUTTON_TITLE" = "Siguiente";
@@ -259,20 +259,20 @@
 /* Message shown when products available for purchase could not be retrieved. */
 "PRODUCT_LIST_COULD_NOT_BE_RETRIEVED" = "La lista de productos no pudo ser obtenida";
 
-/*[UNTRANSLATED] Text for a link displayed when the user does not have a PsiCash account. It encourages them to make one. The word 'PsiCash' must not be translated or transliterated. */
-"PROTECT_YOUR_PURCHASES" = "Protect Your Purchases";
+/* Text for a link displayed when the user does not have a PsiCash account. It encourages them to make one. The word 'PsiCash' must not be translated or transliterated. */
+"PROTECT_YOUR_PURCHASES" = "Protege Tus Compras";
 
 /* Do not translate or transliterate 'PsiCash'. Header of a box providing context that the actions inside the box are related to PsiCash accounts. */
 "PSICASH_ACCOUNT" = "Cuenta PsiCash";
 
-/*[UNTRANSLATED] Do not translate or transliterate 'PsiCash'. Alert message asking user if they are sure they would like to logout of their PsiCash account */
-"PSICASH_ACCOUNT_LOGOUT_CHECK_PROMPT" = "Are you sure you want to log out of your PsiCash account?";
+/* Do not translate or transliterate 'PsiCash'. Alert message asking user if they are sure they would like to logout of their PsiCash account */
+"PSICASH_ACCOUNT_LOGOUT_CHECK_PROMPT" = "¿Seguro que quieres cerrar sesión de tu cuenta PsiCash?";
 
 /* An alert shown when the user logs out of their PsiCash account. The word 'PsiCash' must not be translated or transliterated. */
 "PSICASH_ACCOUNT_LOGOUT_COMPLETE_TITLE" = "Cierre de sesión de cuenta PsiCash completo.";
 
-/*[UNTRANSLATED] Body of modal dialog shown when the user attempts to log out of their PsiCash account and an unexpected error occurs. Please don't modify the link URL. */
-"PSICASH_ACCOUNT_LOGOUT_FAILED_BODY" = "You logout attempt failed unexpectedly. Please try restarting the application.";
+/* Body of modal dialog shown when the user attempts to log out of their PsiCash account and an unexpected error occurs. Please don't modify the link URL. */
+"PSICASH_ACCOUNT_LOGOUT_FAILED_BODY" = "Tu intento de cerrar sesión falló inesperadamente. Por favor intenta reiniciar la aplicación.";
 
 /* Header of a modal dialog that appears when the user tries to log out of their PsiCash account. The word 'PsiCash' must not be translated or transliterated. */
 "PSICASH_ACCOUNT_LOGOUT_TITLE" = "Cierre de sesión de cuenta PsiCash";
@@ -280,8 +280,8 @@
 /* Button title that opens 'PsiCash' account management. */
 "PSICASH_ACCOUNT_MANAGEMENT_2" = "Administrar cuenta";
 
-/*[UNTRANSLATED] An alert shown when the user's PsiCash account tokens expire. This is a normal occurrence (once per year), and the user needs to log into their PsiCash account again to continue to use it. The word 'PsiCash' must not be translated or transliterated. */
-"PSICASH_ACCOUNT_TOKENS_EXPIRED_BODY_2" = "Your PsiCash login has expired. Please log back in.";
+/* An alert shown when the user's PsiCash account tokens expire. This is a normal occurrence (once per year), and the user needs to log into their PsiCash account again to continue to use it. The word 'PsiCash' must not be translated or transliterated. */
+"PSICASH_ACCOUNT_TOKENS_EXPIRED_BODY_2" = "Tu inicio de sesión en PsiCash ha caducado. Por favor inicia sesión nuevamente.";
 
 /* Body text of a modal dialog shown when a PsiCash login succeeds. There is a fixed number of times that a user can merge a pre-account balance into a PsiCash account. This message indicates that the user has hit that limit and the merge that occurred is the last one allowed. The word 'PsiCash' must not be translated or transliterated. */
 "PSICASH_ACCOUNTS_LAST_MERGE_WARNING_BODY" = "Tienes sesión iniciada dentro de tu cuenta PsiCash. El saldo preexistente de este dispositivo ha sido transferido dentro de tu cuenta, pero esta es la última vez que ocurrirá una unificacfión de saldos.";
@@ -346,14 +346,14 @@
 /* Message when the user has made a purchase, and paid successfully, however the transaction is not complete yet and is pending verification */
 "PSICASH_WAIT_TRANSACTION_VERIFIED" = "Por favor espera mientras tu transacción está siendo verificada";
 
-/* Alert message informing user that a Psip */
+/* Alert message informing user that a Psiphon connection is required */
 "PSIPHON_CONNECTION_REQUIRED" = "Una conexion a Psiphon es requerida.";
 
 /* Shown when user is not connected to Psiphon network. Do not translate or transliterate 'Psiphon' */
 "PSIPHON_IS_NOT_CONNECTED" = "Psiphon no está conectado";
 
-/*[UNTRANSLATED] Alert message that the users purchases have been restored successfully */
-"PURCHASES_RESTORED_SUCCESSFULLY" = "Purchases restored successfully";
+/* Alert message that the users purchases have been restored successfully */
+"PURCHASES_RESTORED_SUCCESSFULLY" = "Compras restauradas con éxito";
 
 /* Shown when the user is purchasing PsiCash. PsiCash is a type of credit. Do not translate or transliterate 'PsiCash'. Including ellipses '…' if appropriate. */
 "PURCHASING_PSICASH" = "Comprando PsiCash…";
@@ -370,8 +370,8 @@
 /* Point in a list of scenarios where the user should try refreshing their app receipt to restore an existing subscription */
 "REFRESH_APP_RECEIPT_BUTTON_DESCRIPTION_POINT_2" = "No puede ver una suscripción que compró en éste dispositivo.";
 
-/*[UNTRANSLATED] Button that restores users previous purchases */
-"RESTORE_PURCHASES" = "Restore purchases";
+/* Button that restores users previous purchases */
+"RESTORE_PURCHASES" = "Restaurar compras";
 
 /* Button which, when pressed, attempts to restore any existing subscriptions the user has purchased */
 "RESTORE_SUBSCRIPTION_BUTTON" = "Restaurar Suscripción";
@@ -403,31 +403,31 @@
 /* Do not transliterate 'Speed Boost'. 'Speed Boost' is a reward that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */
 "SPEED_BOOST" = "Turbo Velocidad";
 
-/* Label on a button. Clicking this button will buy 1 hour of Speed Boost. */
+/* Label on a button. Clicking this button will buy 1 hour of Speed Boost. Translate number as well. */
 "SPEED_BOOST_1HR" = "1 hora";
 
-/* Label on a button. Clicking this button will buy 2 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 2 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_2HR" = "2 horas";
 
-/* Label on a button. Clicking this button will buy 3 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 3 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_3HR" = "3 horas";
 
-/* Label on a button. Clicking this button will buy 4 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 4 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_4HR" = "4 horas";
 
-/* Label on a button. Clicking this button will buy 5 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 5 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_5HR" = "5 horas";
 
-/* Label on a button. Clicking this button will buy 6 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 6 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_6HR" = "6 horas";
 
-/* Label on a button. Clicking this button will buy 7 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 7 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_7HR" = "7 horas";
 
-/* Label on a button. Clicking this button will buy 8 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 8 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_8HR" = "8 horas";
 
-/* Label on a button. Clicking this button will buy 9 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 9 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_9HR" = "9 horas";
 
 /* Do not transliterate 'Speed Boost'. 'Speed Boost' is a product that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */

--- a/Shared/Strings/fa-AF.lproj/Localizable.strings
+++ b/Shared/Strings/fa-AF.lproj/Localizable.strings
@@ -142,8 +142,8 @@
 /*[UNTRANSLATED] Do not translate or transliterate 'PsiCash'. Informs the user that they must sign up for a PsiCash account or log in to their PsiCash account in order to user PsiCash features. */
 "LOG_IN_OR_SIGNUP_TO_CONTINUE" = "Log in or create account to continue using PsiCash";
 
-/* Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
-"LOG_OUT_ANY_WAY_BUTTON_TITLE" = "Logout anyway";
+/*[UNTRANSLATED] Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
+"LOG_OUT_ANY_WAY_BUTTON_TITLE_2" = "Log out anyway";
 
 /*[UNTRANSLATED] Title of the button that lets users log out of their account */
 "LOG_OUT_BUTTON_TITLE_2" = "Log out";
@@ -346,7 +346,7 @@
 /*[UNTRANSLATED] Message when the user has made a purchase, and paid successfully, however the transaction is not complete yet and is pending verification */
 "PSICASH_WAIT_TRANSACTION_VERIFIED" = "Please wait while your transaction is being verified";
 
-/*[UNTRANSLATED] Alert message informing user that a Psip */
+/*[UNTRANSLATED] Alert message informing user that a Psiphon connection is required */
 "PSIPHON_CONNECTION_REQUIRED" = "Psiphon Connection Required";
 
 /*[UNTRANSLATED] Shown when user is not connected to Psiphon network. Do not translate or transliterate 'Psiphon' */
@@ -403,31 +403,31 @@
 /*[UNTRANSLATED] Do not transliterate 'Speed Boost'. 'Speed Boost' is a reward that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */
 "SPEED_BOOST" = "Speed Boost";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 1 hour of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 1 hour of Speed Boost. Translate number as well. */
 "SPEED_BOOST_1HR" = "1 hour";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 2 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 2 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_2HR" = "2 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_3HR" = "3 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 4 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 4 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_4HR" = "4 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_5HR" = "5 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 6 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 6 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_6HR" = "6 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_7HR" = "7 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 8 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 8 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_8HR" = "8 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_9HR" = "9 hours";
 
 /*[UNTRANSLATED] Do not transliterate 'Speed Boost'. 'Speed Boost' is a product that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */

--- a/Shared/Strings/fa.lproj/Localizable.strings
+++ b/Shared/Strings/fa.lproj/Localizable.strings
@@ -142,8 +142,8 @@
 /*[UNTRANSLATED] Do not translate or transliterate 'PsiCash'. Informs the user that they must sign up for a PsiCash account or log in to their PsiCash account in order to user PsiCash features. */
 "LOG_IN_OR_SIGNUP_TO_CONTINUE" = "Log in or create account to continue using PsiCash";
 
-/* Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
-"LOG_OUT_ANY_WAY_BUTTON_TITLE" = "Logout anyway";
+/*[UNTRANSLATED] Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
+"LOG_OUT_ANY_WAY_BUTTON_TITLE_2" = "Log out anyway";
 
 /* Title of the button that lets users log out of their account */
 "LOG_OUT_BUTTON_TITLE_2" = "خروج";
@@ -346,7 +346,7 @@
 /* Message when the user has made a purchase, and paid successfully, however the transaction is not complete yet and is pending verification */
 "PSICASH_WAIT_TRANSACTION_VERIFIED" = "لطفا صبر کنید تا تراکنش شما تایید شود";
 
-/* Alert message informing user that a Psip */
+/* Alert message informing user that a Psiphon connection is required */
 "PSIPHON_CONNECTION_REQUIRED" = "اتصال Psiphon الزامیست";
 
 /* Shown when user is not connected to Psiphon network. Do not translate or transliterate 'Psiphon' */
@@ -403,31 +403,31 @@
 /* Do not transliterate 'Speed Boost'. 'Speed Boost' is a reward that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */
 "SPEED_BOOST" = "اسپید بوست";
 
-/* Label on a button. Clicking this button will buy 1 hour of Speed Boost. */
+/* Label on a button. Clicking this button will buy 1 hour of Speed Boost. Translate number as well. */
 "SPEED_BOOST_1HR" = "۱ ساعت";
 
-/* Label on a button. Clicking this button will buy 2 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 2 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_2HR" = "۲ ساعت";
 
-/* Label on a button. Clicking this button will buy 3 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 3 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_3HR" = "۳ ساعت";
 
-/* Label on a button. Clicking this button will buy 4 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 4 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_4HR" = "۴ ساعت";
 
-/* Label on a button. Clicking this button will buy 5 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 5 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_5HR" = "۵ ساعت";
 
-/* Label on a button. Clicking this button will buy 6 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 6 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_6HR" = "۶ ساعت";
 
-/* Label on a button. Clicking this button will buy 7 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 7 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_7HR" = "۷ ساعت";
 
-/* Label on a button. Clicking this button will buy 8 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 8 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_8HR" = "۸ ساعت";
 
-/* Label on a button. Clicking this button will buy 9 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 9 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_9HR" = "۹ ساعت";
 
 /* Do not transliterate 'Speed Boost'. 'Speed Boost' is a product that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */

--- a/Shared/Strings/fi.lproj/Localizable.strings
+++ b/Shared/Strings/fi.lproj/Localizable.strings
@@ -142,8 +142,8 @@
 /*[UNTRANSLATED] Do not translate or transliterate 'PsiCash'. Informs the user that they must sign up for a PsiCash account or log in to their PsiCash account in order to user PsiCash features. */
 "LOG_IN_OR_SIGNUP_TO_CONTINUE" = "Log in or create account to continue using PsiCash";
 
-/* Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
-"LOG_OUT_ANY_WAY_BUTTON_TITLE" = "Logout anyway";
+/*[UNTRANSLATED] Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
+"LOG_OUT_ANY_WAY_BUTTON_TITLE_2" = "Log out anyway";
 
 /*[UNTRANSLATED] Title of the button that lets users log out of their account */
 "LOG_OUT_BUTTON_TITLE_2" = "Log out";
@@ -346,7 +346,7 @@
 /*[UNTRANSLATED] Message when the user has made a purchase, and paid successfully, however the transaction is not complete yet and is pending verification */
 "PSICASH_WAIT_TRANSACTION_VERIFIED" = "Please wait while your transaction is being verified";
 
-/*[UNTRANSLATED] Alert message informing user that a Psip */
+/*[UNTRANSLATED] Alert message informing user that a Psiphon connection is required */
 "PSIPHON_CONNECTION_REQUIRED" = "Psiphon Connection Required";
 
 /*[UNTRANSLATED] Shown when user is not connected to Psiphon network. Do not translate or transliterate 'Psiphon' */
@@ -403,31 +403,31 @@
 /*[UNTRANSLATED] Do not transliterate 'Speed Boost'. 'Speed Boost' is a reward that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */
 "SPEED_BOOST" = "Speed Boost";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 1 hour of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 1 hour of Speed Boost. Translate number as well. */
 "SPEED_BOOST_1HR" = "1 hour";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 2 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 2 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_2HR" = "2 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_3HR" = "3 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 4 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 4 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_4HR" = "4 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_5HR" = "5 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 6 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 6 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_6HR" = "6 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_7HR" = "7 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 8 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 8 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_8HR" = "8 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_9HR" = "9 hours";
 
 /*[UNTRANSLATED] Do not transliterate 'Speed Boost'. 'Speed Boost' is a product that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */

--- a/Shared/Strings/fr.lproj/Localizable.strings
+++ b/Shared/Strings/fr.lproj/Localizable.strings
@@ -143,7 +143,7 @@
 "LOG_IN_OR_SIGNUP_TO_CONTINUE" = "Log in or create account to continue using PsiCash";
 
 /* Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
-"LOG_OUT_ANY_WAY_BUTTON_TITLE" = "Me déconnecter quand même";
+"LOG_OUT_ANY_WAY_BUTTON_TITLE_2" = "Me déconnecter quand même";
 
 /* Title of the button that lets users log out of their account */
 "LOG_OUT_BUTTON_TITLE_2" = "Déconnexion";
@@ -346,7 +346,7 @@
 /* Message when the user has made a purchase, and paid successfully, however the transaction is not complete yet and is pending verification */
 "PSICASH_WAIT_TRANSACTION_VERIFIED" = "Veuillez patienter pendant la vérification de votre transaction";
 
-/* Alert message informing user that a Psip */
+/* Alert message informing user that a Psiphon connection is required */
 "PSIPHON_CONNECTION_REQUIRED" = "La connexion à Psiphon est exigée";
 
 /* Shown when user is not connected to Psiphon network. Do not translate or transliterate 'Psiphon' */
@@ -403,31 +403,31 @@
 /* Do not transliterate 'Speed Boost'. 'Speed Boost' is a reward that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */
 "SPEED_BOOST" = "Survitesse";
 
-/* Label on a button. Clicking this button will buy 1 hour of Speed Boost. */
+/* Label on a button. Clicking this button will buy 1 hour of Speed Boost. Translate number as well. */
 "SPEED_BOOST_1HR" = "1 heure";
 
-/* Label on a button. Clicking this button will buy 2 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 2 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_2HR" = "2 heures";
 
-/* Label on a button. Clicking this button will buy 3 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 3 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_3HR" = "3 heures";
 
-/* Label on a button. Clicking this button will buy 4 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 4 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_4HR" = "4 heures";
 
-/* Label on a button. Clicking this button will buy 5 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 5 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_5HR" = "5 heures";
 
-/* Label on a button. Clicking this button will buy 6 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 6 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_6HR" = "6 heures";
 
-/* Label on a button. Clicking this button will buy 7 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 7 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_7HR" = "7 heures";
 
-/* Label on a button. Clicking this button will buy 8 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 8 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_8HR" = "8 heures";
 
-/* Label on a button. Clicking this button will buy 9 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 9 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_9HR" = "9 heures";
 
 /* Do not transliterate 'Speed Boost'. 'Speed Boost' is a product that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */

--- a/Shared/Strings/he.lproj/Localizable.strings
+++ b/Shared/Strings/he.lproj/Localizable.strings
@@ -142,8 +142,8 @@
 /*[UNTRANSLATED] Do not translate or transliterate 'PsiCash'. Informs the user that they must sign up for a PsiCash account or log in to their PsiCash account in order to user PsiCash features. */
 "LOG_IN_OR_SIGNUP_TO_CONTINUE" = "Log in or create account to continue using PsiCash";
 
-/* Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
-"LOG_OUT_ANY_WAY_BUTTON_TITLE" = "Logout anyway";
+/*[UNTRANSLATED] Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
+"LOG_OUT_ANY_WAY_BUTTON_TITLE_2" = "Log out anyway";
 
 /*[UNTRANSLATED] Title of the button that lets users log out of their account */
 "LOG_OUT_BUTTON_TITLE_2" = "Log out";
@@ -346,7 +346,7 @@
 /* Message when the user has made a purchase, and paid successfully, however the transaction is not complete yet and is pending verification */
 "PSICASH_WAIT_TRANSACTION_VERIFIED" = "אנא המתן בזמן שהעסקה שלך מוודאת";
 
-/*[UNTRANSLATED] Alert message informing user that a Psip */
+/*[UNTRANSLATED] Alert message informing user that a Psiphon connection is required */
 "PSIPHON_CONNECTION_REQUIRED" = "Psiphon Connection Required";
 
 /* Shown when user is not connected to Psiphon network. Do not translate or transliterate 'Psiphon' */
@@ -403,31 +403,31 @@
 /* Do not transliterate 'Speed Boost'. 'Speed Boost' is a reward that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */
 "SPEED_BOOST" = "תמריץ מהירות";
 
-/* Label on a button. Clicking this button will buy 1 hour of Speed Boost. */
+/* Label on a button. Clicking this button will buy 1 hour of Speed Boost. Translate number as well. */
 "SPEED_BOOST_1HR" = "שעה 1";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 2 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 2 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_2HR" = "2 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_3HR" = "3 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 4 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 4 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_4HR" = "4 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_5HR" = "5 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 6 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 6 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_6HR" = "6 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_7HR" = "7 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 8 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 8 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_8HR" = "8 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_9HR" = "9 hours";
 
 /* Do not transliterate 'Speed Boost'. 'Speed Boost' is a product that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */

--- a/Shared/Strings/hi.lproj/Localizable.strings
+++ b/Shared/Strings/hi.lproj/Localizable.strings
@@ -142,8 +142,8 @@
 /*[UNTRANSLATED] Do not translate or transliterate 'PsiCash'. Informs the user that they must sign up for a PsiCash account or log in to their PsiCash account in order to user PsiCash features. */
 "LOG_IN_OR_SIGNUP_TO_CONTINUE" = "Log in or create account to continue using PsiCash";
 
-/* Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
-"LOG_OUT_ANY_WAY_BUTTON_TITLE" = "Logout anyway";
+/*[UNTRANSLATED] Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
+"LOG_OUT_ANY_WAY_BUTTON_TITLE_2" = "Log out anyway";
 
 /*[UNTRANSLATED] Title of the button that lets users log out of their account */
 "LOG_OUT_BUTTON_TITLE_2" = "Log out";
@@ -346,7 +346,7 @@
 /*[UNTRANSLATED] Message when the user has made a purchase, and paid successfully, however the transaction is not complete yet and is pending verification */
 "PSICASH_WAIT_TRANSACTION_VERIFIED" = "Please wait while your transaction is being verified";
 
-/*[UNTRANSLATED] Alert message informing user that a Psip */
+/*[UNTRANSLATED] Alert message informing user that a Psiphon connection is required */
 "PSIPHON_CONNECTION_REQUIRED" = "Psiphon Connection Required";
 
 /*[UNTRANSLATED] Shown when user is not connected to Psiphon network. Do not translate or transliterate 'Psiphon' */
@@ -403,31 +403,31 @@
 /*[UNTRANSLATED] Do not transliterate 'Speed Boost'. 'Speed Boost' is a reward that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */
 "SPEED_BOOST" = "Speed Boost";
 
-/* Label on a button. Clicking this button will buy 1 hour of Speed Boost. */
+/* Label on a button. Clicking this button will buy 1 hour of Speed Boost. Translate number as well. */
 "SPEED_BOOST_1HR" = "1 घंटा";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 2 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 2 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_2HR" = "2 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_3HR" = "3 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 4 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 4 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_4HR" = "4 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_5HR" = "5 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 6 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 6 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_6HR" = "6 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_7HR" = "7 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 8 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 8 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_8HR" = "8 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_9HR" = "9 hours";
 
 /*[UNTRANSLATED] Do not transliterate 'Speed Boost'. 'Speed Boost' is a product that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */

--- a/Shared/Strings/hr.lproj/Localizable.strings
+++ b/Shared/Strings/hr.lproj/Localizable.strings
@@ -142,8 +142,8 @@
 /*[UNTRANSLATED] Do not translate or transliterate 'PsiCash'. Informs the user that they must sign up for a PsiCash account or log in to their PsiCash account in order to user PsiCash features. */
 "LOG_IN_OR_SIGNUP_TO_CONTINUE" = "Log in or create account to continue using PsiCash";
 
-/* Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
-"LOG_OUT_ANY_WAY_BUTTON_TITLE" = "Logout anyway";
+/*[UNTRANSLATED] Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
+"LOG_OUT_ANY_WAY_BUTTON_TITLE_2" = "Log out anyway";
 
 /* Title of the button that lets users log out of their account */
 "LOG_OUT_BUTTON_TITLE_2" = "Odjava";
@@ -346,7 +346,7 @@
 /*[UNTRANSLATED] Message when the user has made a purchase, and paid successfully, however the transaction is not complete yet and is pending verification */
 "PSICASH_WAIT_TRANSACTION_VERIFIED" = "Please wait while your transaction is being verified";
 
-/*[UNTRANSLATED] Alert message informing user that a Psip */
+/*[UNTRANSLATED] Alert message informing user that a Psiphon connection is required */
 "PSIPHON_CONNECTION_REQUIRED" = "Psiphon Connection Required";
 
 /*[UNTRANSLATED] Shown when user is not connected to Psiphon network. Do not translate or transliterate 'Psiphon' */
@@ -403,31 +403,31 @@
 /*[UNTRANSLATED] Do not transliterate 'Speed Boost'. 'Speed Boost' is a reward that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */
 "SPEED_BOOST" = "Speed Boost";
 
-/* Label on a button. Clicking this button will buy 1 hour of Speed Boost. */
+/* Label on a button. Clicking this button will buy 1 hour of Speed Boost. Translate number as well. */
 "SPEED_BOOST_1HR" = "1 sat";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 2 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 2 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_2HR" = "2 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_3HR" = "3 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 4 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 4 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_4HR" = "4 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_5HR" = "5 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 6 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 6 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_6HR" = "6 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_7HR" = "7 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 8 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 8 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_8HR" = "8 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_9HR" = "9 hours";
 
 /* Do not transliterate 'Speed Boost'. 'Speed Boost' is a product that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */

--- a/Shared/Strings/id.lproj/Localizable.strings
+++ b/Shared/Strings/id.lproj/Localizable.strings
@@ -142,8 +142,8 @@
 /*[UNTRANSLATED] Do not translate or transliterate 'PsiCash'. Informs the user that they must sign up for a PsiCash account or log in to their PsiCash account in order to user PsiCash features. */
 "LOG_IN_OR_SIGNUP_TO_CONTINUE" = "Log in or create account to continue using PsiCash";
 
-/* Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
-"LOG_OUT_ANY_WAY_BUTTON_TITLE" = "Logout anyway";
+/*[UNTRANSLATED] Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
+"LOG_OUT_ANY_WAY_BUTTON_TITLE_2" = "Log out anyway";
 
 /* Title of the button that lets users log out of their account */
 "LOG_OUT_BUTTON_TITLE_2" = "Keluar";
@@ -346,7 +346,7 @@
 /*[UNTRANSLATED] Message when the user has made a purchase, and paid successfully, however the transaction is not complete yet and is pending verification */
 "PSICASH_WAIT_TRANSACTION_VERIFIED" = "Please wait while your transaction is being verified";
 
-/*[UNTRANSLATED] Alert message informing user that a Psip */
+/*[UNTRANSLATED] Alert message informing user that a Psiphon connection is required */
 "PSIPHON_CONNECTION_REQUIRED" = "Psiphon Connection Required";
 
 /*[UNTRANSLATED] Shown when user is not connected to Psiphon network. Do not translate or transliterate 'Psiphon' */
@@ -403,31 +403,31 @@
 /*[UNTRANSLATED] Do not transliterate 'Speed Boost'. 'Speed Boost' is a reward that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */
 "SPEED_BOOST" = "Speed Boost";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 1 hour of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 1 hour of Speed Boost. Translate number as well. */
 "SPEED_BOOST_1HR" = "1 hour";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 2 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 2 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_2HR" = "2 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_3HR" = "3 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 4 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 4 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_4HR" = "4 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_5HR" = "5 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 6 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 6 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_6HR" = "6 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_7HR" = "7 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 8 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 8 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_8HR" = "8 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_9HR" = "9 hours";
 
 /* Do not transliterate 'Speed Boost'. 'Speed Boost' is a product that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */

--- a/Shared/Strings/it.lproj/Localizable.strings
+++ b/Shared/Strings/it.lproj/Localizable.strings
@@ -142,8 +142,8 @@
 /*[UNTRANSLATED] Do not translate or transliterate 'PsiCash'. Informs the user that they must sign up for a PsiCash account or log in to their PsiCash account in order to user PsiCash features. */
 "LOG_IN_OR_SIGNUP_TO_CONTINUE" = "Log in or create account to continue using PsiCash";
 
-/* Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
-"LOG_OUT_ANY_WAY_BUTTON_TITLE" = "Logout anyway";
+/*[UNTRANSLATED] Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
+"LOG_OUT_ANY_WAY_BUTTON_TITLE_2" = "Log out anyway";
 
 /*[UNTRANSLATED] Title of the button that lets users log out of their account */
 "LOG_OUT_BUTTON_TITLE_2" = "Log out";
@@ -346,7 +346,7 @@
 /*[UNTRANSLATED] Message when the user has made a purchase, and paid successfully, however the transaction is not complete yet and is pending verification */
 "PSICASH_WAIT_TRANSACTION_VERIFIED" = "Please wait while your transaction is being verified";
 
-/*[UNTRANSLATED] Alert message informing user that a Psip */
+/*[UNTRANSLATED] Alert message informing user that a Psiphon connection is required */
 "PSIPHON_CONNECTION_REQUIRED" = "Psiphon Connection Required";
 
 /*[UNTRANSLATED] Shown when user is not connected to Psiphon network. Do not translate or transliterate 'Psiphon' */
@@ -403,31 +403,31 @@
 /*[UNTRANSLATED] Do not transliterate 'Speed Boost'. 'Speed Boost' is a reward that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */
 "SPEED_BOOST" = "Speed Boost";
 
-/* Label on a button. Clicking this button will buy 1 hour of Speed Boost. */
+/* Label on a button. Clicking this button will buy 1 hour of Speed Boost. Translate number as well. */
 "SPEED_BOOST_1HR" = "1 ora";
 
-/* Label on a button. Clicking this button will buy 2 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 2 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_2HR" = "2 ore";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_3HR" = "3 hours";
 
-/* Label on a button. Clicking this button will buy 4 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 4 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_4HR" = "4 ore";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_5HR" = "5 hours";
 
-/* Label on a button. Clicking this button will buy 6 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 6 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_6HR" = "6 ore";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_7HR" = "7 hours";
 
-/* Label on a button. Clicking this button will buy 8 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 8 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_8HR" = "8 ore";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_9HR" = "9 hours";
 
 /*[UNTRANSLATED] Do not transliterate 'Speed Boost'. 'Speed Boost' is a product that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */

--- a/Shared/Strings/kk.lproj/Localizable.strings
+++ b/Shared/Strings/kk.lproj/Localizable.strings
@@ -142,8 +142,8 @@
 /*[UNTRANSLATED] Do not translate or transliterate 'PsiCash'. Informs the user that they must sign up for a PsiCash account or log in to their PsiCash account in order to user PsiCash features. */
 "LOG_IN_OR_SIGNUP_TO_CONTINUE" = "Log in or create account to continue using PsiCash";
 
-/* Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
-"LOG_OUT_ANY_WAY_BUTTON_TITLE" = "Logout anyway";
+/*[UNTRANSLATED] Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
+"LOG_OUT_ANY_WAY_BUTTON_TITLE_2" = "Log out anyway";
 
 /*[UNTRANSLATED] Title of the button that lets users log out of their account */
 "LOG_OUT_BUTTON_TITLE_2" = "Log out";
@@ -346,7 +346,7 @@
 /*[UNTRANSLATED] Message when the user has made a purchase, and paid successfully, however the transaction is not complete yet and is pending verification */
 "PSICASH_WAIT_TRANSACTION_VERIFIED" = "Please wait while your transaction is being verified";
 
-/*[UNTRANSLATED] Alert message informing user that a Psip */
+/*[UNTRANSLATED] Alert message informing user that a Psiphon connection is required */
 "PSIPHON_CONNECTION_REQUIRED" = "Psiphon Connection Required";
 
 /*[UNTRANSLATED] Shown when user is not connected to Psiphon network. Do not translate or transliterate 'Psiphon' */
@@ -403,31 +403,31 @@
 /*[UNTRANSLATED] Do not transliterate 'Speed Boost'. 'Speed Boost' is a reward that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */
 "SPEED_BOOST" = "Speed Boost";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 1 hour of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 1 hour of Speed Boost. Translate number as well. */
 "SPEED_BOOST_1HR" = "1 hour";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 2 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 2 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_2HR" = "2 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_3HR" = "3 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 4 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 4 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_4HR" = "4 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_5HR" = "5 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 6 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 6 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_6HR" = "6 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_7HR" = "7 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 8 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 8 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_8HR" = "8 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_9HR" = "9 hours";
 
 /*[UNTRANSLATED] Do not transliterate 'Speed Boost'. 'Speed Boost' is a product that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */

--- a/Shared/Strings/km.lproj/Localizable.strings
+++ b/Shared/Strings/km.lproj/Localizable.strings
@@ -142,8 +142,8 @@
 /*[UNTRANSLATED] Do not translate or transliterate 'PsiCash'. Informs the user that they must sign up for a PsiCash account or log in to their PsiCash account in order to user PsiCash features. */
 "LOG_IN_OR_SIGNUP_TO_CONTINUE" = "Log in or create account to continue using PsiCash";
 
-/* Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
-"LOG_OUT_ANY_WAY_BUTTON_TITLE" = "Logout anyway";
+/*[UNTRANSLATED] Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
+"LOG_OUT_ANY_WAY_BUTTON_TITLE_2" = "Log out anyway";
 
 /*[UNTRANSLATED] Title of the button that lets users log out of their account */
 "LOG_OUT_BUTTON_TITLE_2" = "Log out";
@@ -346,7 +346,7 @@
 /* Message when the user has made a purchase, and paid successfully, however the transaction is not complete yet and is pending verification */
 "PSICASH_WAIT_TRANSACTION_VERIFIED" = "សូមរង់ចាំ នៅពេលប្រតិបត្តិការរបស់អ្នកកំពុងត្រូវបានផ្ទៀងផ្ទាត់";
 
-/*[UNTRANSLATED] Alert message informing user that a Psip */
+/*[UNTRANSLATED] Alert message informing user that a Psiphon connection is required */
 "PSIPHON_CONNECTION_REQUIRED" = "Psiphon Connection Required";
 
 /* Shown when user is not connected to Psiphon network. Do not translate or transliterate 'Psiphon' */
@@ -403,31 +403,31 @@
 /* Do not transliterate 'Speed Boost'. 'Speed Boost' is a reward that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */
 "SPEED_BOOST" = "បន្ថែមល្បឿន";
 
-/* Label on a button. Clicking this button will buy 1 hour of Speed Boost. */
+/* Label on a button. Clicking this button will buy 1 hour of Speed Boost. Translate number as well. */
 "SPEED_BOOST_1HR" = "1 ម៉ោង";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 2 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 2 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_2HR" = "2 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_3HR" = "3 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 4 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 4 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_4HR" = "4 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_5HR" = "5 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 6 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 6 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_6HR" = "6 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_7HR" = "7 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 8 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 8 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_8HR" = "8 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_9HR" = "9 hours";
 
 /* Do not transliterate 'Speed Boost'. 'Speed Boost' is a product that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */

--- a/Shared/Strings/ko.lproj/Localizable.strings
+++ b/Shared/Strings/ko.lproj/Localizable.strings
@@ -142,8 +142,8 @@
 /*[UNTRANSLATED] Do not translate or transliterate 'PsiCash'. Informs the user that they must sign up for a PsiCash account or log in to their PsiCash account in order to user PsiCash features. */
 "LOG_IN_OR_SIGNUP_TO_CONTINUE" = "Log in or create account to continue using PsiCash";
 
-/* Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
-"LOG_OUT_ANY_WAY_BUTTON_TITLE" = "Logout anyway";
+/*[UNTRANSLATED] Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
+"LOG_OUT_ANY_WAY_BUTTON_TITLE_2" = "Log out anyway";
 
 /* Title of the button that lets users log out of their account */
 "LOG_OUT_BUTTON_TITLE_2" = "로그아웃";
@@ -346,7 +346,7 @@
 /*[UNTRANSLATED] Message when the user has made a purchase, and paid successfully, however the transaction is not complete yet and is pending verification */
 "PSICASH_WAIT_TRANSACTION_VERIFIED" = "Please wait while your transaction is being verified";
 
-/*[UNTRANSLATED] Alert message informing user that a Psip */
+/*[UNTRANSLATED] Alert message informing user that a Psiphon connection is required */
 "PSIPHON_CONNECTION_REQUIRED" = "Psiphon Connection Required";
 
 /*[UNTRANSLATED] Shown when user is not connected to Psiphon network. Do not translate or transliterate 'Psiphon' */
@@ -403,31 +403,31 @@
 /*[UNTRANSLATED] Do not transliterate 'Speed Boost'. 'Speed Boost' is a reward that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */
 "SPEED_BOOST" = "Speed Boost";
 
-/* Label on a button. Clicking this button will buy 1 hour of Speed Boost. */
+/* Label on a button. Clicking this button will buy 1 hour of Speed Boost. Translate number as well. */
 "SPEED_BOOST_1HR" = "1시간";
 
-/* Label on a button. Clicking this button will buy 2 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 2 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_2HR" = "2시간";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_3HR" = "3 hours";
 
-/* Label on a button. Clicking this button will buy 4 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 4 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_4HR" = "4시간";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_5HR" = "5 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 6 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 6 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_6HR" = "6 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_7HR" = "7 hours";
 
-/* Label on a button. Clicking this button will buy 8 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 8 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_8HR" = "8시간";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_9HR" = "9 hours";
 
 /*[UNTRANSLATED] Do not transliterate 'Speed Boost'. 'Speed Boost' is a product that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */

--- a/Shared/Strings/ky.lproj/Localizable.strings
+++ b/Shared/Strings/ky.lproj/Localizable.strings
@@ -142,8 +142,8 @@
 /*[UNTRANSLATED] Do not translate or transliterate 'PsiCash'. Informs the user that they must sign up for a PsiCash account or log in to their PsiCash account in order to user PsiCash features. */
 "LOG_IN_OR_SIGNUP_TO_CONTINUE" = "Log in or create account to continue using PsiCash";
 
-/* Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
-"LOG_OUT_ANY_WAY_BUTTON_TITLE" = "Logout anyway";
+/*[UNTRANSLATED] Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
+"LOG_OUT_ANY_WAY_BUTTON_TITLE_2" = "Log out anyway";
 
 /*[UNTRANSLATED] Title of the button that lets users log out of their account */
 "LOG_OUT_BUTTON_TITLE_2" = "Log out";
@@ -346,7 +346,7 @@
 /*[UNTRANSLATED] Message when the user has made a purchase, and paid successfully, however the transaction is not complete yet and is pending verification */
 "PSICASH_WAIT_TRANSACTION_VERIFIED" = "Please wait while your transaction is being verified";
 
-/*[UNTRANSLATED] Alert message informing user that a Psip */
+/*[UNTRANSLATED] Alert message informing user that a Psiphon connection is required */
 "PSIPHON_CONNECTION_REQUIRED" = "Psiphon Connection Required";
 
 /*[UNTRANSLATED] Shown when user is not connected to Psiphon network. Do not translate or transliterate 'Psiphon' */
@@ -403,31 +403,31 @@
 /*[UNTRANSLATED] Do not transliterate 'Speed Boost'. 'Speed Boost' is a reward that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */
 "SPEED_BOOST" = "Speed Boost";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 1 hour of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 1 hour of Speed Boost. Translate number as well. */
 "SPEED_BOOST_1HR" = "1 hour";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 2 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 2 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_2HR" = "2 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_3HR" = "3 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 4 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 4 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_4HR" = "4 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_5HR" = "5 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 6 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 6 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_6HR" = "6 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_7HR" = "7 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 8 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 8 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_8HR" = "8 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_9HR" = "9 hours";
 
 /*[UNTRANSLATED] Do not transliterate 'Speed Boost'. 'Speed Boost' is a product that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */

--- a/Shared/Strings/my.lproj/Localizable.strings
+++ b/Shared/Strings/my.lproj/Localizable.strings
@@ -142,8 +142,8 @@
 /*[UNTRANSLATED] Do not translate or transliterate 'PsiCash'. Informs the user that they must sign up for a PsiCash account or log in to their PsiCash account in order to user PsiCash features. */
 "LOG_IN_OR_SIGNUP_TO_CONTINUE" = "Log in or create account to continue using PsiCash";
 
-/* Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
-"LOG_OUT_ANY_WAY_BUTTON_TITLE" = "Logout anyway";
+/*[UNTRANSLATED] Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
+"LOG_OUT_ANY_WAY_BUTTON_TITLE_2" = "Log out anyway";
 
 /* Title of the button that lets users log out of their account */
 "LOG_OUT_BUTTON_TITLE_2" = "ထွက်မယ်";
@@ -346,7 +346,7 @@
 /* Message when the user has made a purchase, and paid successfully, however the transaction is not complete yet and is pending verification */
 "PSICASH_WAIT_TRANSACTION_VERIFIED" = "သင့်ရောင်းဝယ်မှုအား အတည်ပြုနေစဥ် ကျေးဇူးပြု၍ ခဏစောင့်ပေးပါ";
 
-/* Alert message informing user that a Psip */
+/* Alert message informing user that a Psiphon connection is required */
 "PSIPHON_CONNECTION_REQUIRED" = "Psiphon ချိတ်ဆက်မှုလိုအပ်သည်";
 
 /* Shown when user is not connected to Psiphon network. Do not translate or transliterate 'Psiphon' */
@@ -403,31 +403,31 @@
 /* Do not transliterate 'Speed Boost'. 'Speed Boost' is a reward that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */
 "SPEED_BOOST" = "နှုန်းမြင့်";
 
-/* Label on a button. Clicking this button will buy 1 hour of Speed Boost. */
+/* Label on a button. Clicking this button will buy 1 hour of Speed Boost. Translate number as well. */
 "SPEED_BOOST_1HR" = "၁ နာရီ";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 2 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 2 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_2HR" = "2 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_3HR" = "3 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 4 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 4 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_4HR" = "4 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_5HR" = "5 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 6 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 6 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_6HR" = "6 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_7HR" = "7 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 8 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 8 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_8HR" = "8 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_9HR" = "9 hours";
 
 /* Do not transliterate 'Speed Boost'. 'Speed Boost' is a product that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */

--- a/Shared/Strings/nb.lproj/Localizable.strings
+++ b/Shared/Strings/nb.lproj/Localizable.strings
@@ -142,8 +142,8 @@
 /*[UNTRANSLATED] Do not translate or transliterate 'PsiCash'. Informs the user that they must sign up for a PsiCash account or log in to their PsiCash account in order to user PsiCash features. */
 "LOG_IN_OR_SIGNUP_TO_CONTINUE" = "Log in or create account to continue using PsiCash";
 
-/* Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
-"LOG_OUT_ANY_WAY_BUTTON_TITLE" = "Logout anyway";
+/*[UNTRANSLATED] Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
+"LOG_OUT_ANY_WAY_BUTTON_TITLE_2" = "Log out anyway";
 
 /* Title of the button that lets users log out of their account */
 "LOG_OUT_BUTTON_TITLE_2" = "Logg ut";
@@ -346,7 +346,7 @@
 /*[UNTRANSLATED] Message when the user has made a purchase, and paid successfully, however the transaction is not complete yet and is pending verification */
 "PSICASH_WAIT_TRANSACTION_VERIFIED" = "Please wait while your transaction is being verified";
 
-/*[UNTRANSLATED] Alert message informing user that a Psip */
+/*[UNTRANSLATED] Alert message informing user that a Psiphon connection is required */
 "PSIPHON_CONNECTION_REQUIRED" = "Psiphon Connection Required";
 
 /*[UNTRANSLATED] Shown when user is not connected to Psiphon network. Do not translate or transliterate 'Psiphon' */
@@ -403,31 +403,31 @@
 /*[UNTRANSLATED] Do not transliterate 'Speed Boost'. 'Speed Boost' is a reward that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */
 "SPEED_BOOST" = "Speed Boost";
 
-/* Label on a button. Clicking this button will buy 1 hour of Speed Boost. */
+/* Label on a button. Clicking this button will buy 1 hour of Speed Boost. Translate number as well. */
 "SPEED_BOOST_1HR" = "1 time";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 2 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 2 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_2HR" = "2 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_3HR" = "3 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 4 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 4 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_4HR" = "4 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_5HR" = "5 hours";
 
-/* Label on a button. Clicking this button will buy 6 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 6 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_6HR" = "6 timer";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_7HR" = "7 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 8 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 8 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_8HR" = "8 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_9HR" = "9 hours";
 
 /*[UNTRANSLATED] Do not transliterate 'Speed Boost'. 'Speed Boost' is a product that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */

--- a/Shared/Strings/nl.lproj/Localizable.strings
+++ b/Shared/Strings/nl.lproj/Localizable.strings
@@ -143,7 +143,7 @@
 "LOG_IN_OR_SIGNUP_TO_CONTINUE" = "Log in or create account to continue using PsiCash";
 
 /* Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
-"LOG_OUT_ANY_WAY_BUTTON_TITLE" = "Logout anyway";
+"LOG_OUT_ANY_WAY_BUTTON_TITLE_2" = "Log toch uit";
 
 /* Title of the button that lets users log out of their account */
 "LOG_OUT_BUTTON_TITLE_2" = "Uitloggen";
@@ -346,7 +346,7 @@
 /* Message when the user has made a purchase, and paid successfully, however the transaction is not complete yet and is pending verification */
 "PSICASH_WAIT_TRANSACTION_VERIFIED" = "Een ogenblik geduld terwijl uw transactie wordt geverifieerd";
 
-/* Alert message informing user that a Psip */
+/* Alert message informing user that a Psiphon connection is required */
 "PSIPHON_CONNECTION_REQUIRED" = "Psiphon-verbinding vereist";
 
 /* Shown when user is not connected to Psiphon network. Do not translate or transliterate 'Psiphon' */
@@ -403,31 +403,31 @@
 /*[UNTRANSLATED] Do not transliterate 'Speed Boost'. 'Speed Boost' is a reward that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */
 "SPEED_BOOST" = "Speed Boost";
 
-/* Label on a button. Clicking this button will buy 1 hour of Speed Boost. */
+/* Label on a button. Clicking this button will buy 1 hour of Speed Boost. Translate number as well. */
 "SPEED_BOOST_1HR" = "1 uur";
 
-/* Label on a button. Clicking this button will buy 2 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 2 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_2HR" = "2 uur";
 
-/* Label on a button. Clicking this button will buy 3 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 3 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_3HR" = "3 uur";
 
-/* Label on a button. Clicking this button will buy 4 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 4 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_4HR" = "4 uur";
 
-/* Label on a button. Clicking this button will buy 5 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 5 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_5HR" = "5 uur";
 
-/* Label on a button. Clicking this button will buy 6 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 6 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_6HR" = "6 uur";
 
-/* Label on a button. Clicking this button will buy 7 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 7 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_7HR" = "7 uur";
 
-/* Label on a button. Clicking this button will buy 8 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 8 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_8HR" = "8 uur";
 
-/* Label on a button. Clicking this button will buy 9 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 9 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_9HR" = "9 uur";
 
 /* Do not transliterate 'Speed Boost'. 'Speed Boost' is a product that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */

--- a/Shared/Strings/pt-BR.lproj/Localizable.strings
+++ b/Shared/Strings/pt-BR.lproj/Localizable.strings
@@ -142,8 +142,8 @@
 /*[UNTRANSLATED] Do not translate or transliterate 'PsiCash'. Informs the user that they must sign up for a PsiCash account or log in to their PsiCash account in order to user PsiCash features. */
 "LOG_IN_OR_SIGNUP_TO_CONTINUE" = "Log in or create account to continue using PsiCash";
 
-/* Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
-"LOG_OUT_ANY_WAY_BUTTON_TITLE" = "Logout anyway";
+/*[UNTRANSLATED] Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
+"LOG_OUT_ANY_WAY_BUTTON_TITLE_2" = "Log out anyway";
 
 /* Title of the button that lets users log out of their account */
 "LOG_OUT_BUTTON_TITLE_2" = "Sair";
@@ -346,7 +346,7 @@
 /*[UNTRANSLATED] Message when the user has made a purchase, and paid successfully, however the transaction is not complete yet and is pending verification */
 "PSICASH_WAIT_TRANSACTION_VERIFIED" = "Please wait while your transaction is being verified";
 
-/*[UNTRANSLATED] Alert message informing user that a Psip */
+/*[UNTRANSLATED] Alert message informing user that a Psiphon connection is required */
 "PSIPHON_CONNECTION_REQUIRED" = "Psiphon Connection Required";
 
 /*[UNTRANSLATED] Shown when user is not connected to Psiphon network. Do not translate or transliterate 'Psiphon' */
@@ -403,31 +403,31 @@
 /* Do not transliterate 'Speed Boost'. 'Speed Boost' is a reward that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */
 "SPEED_BOOST" = "Velocidade turbinada";
 
-/* Label on a button. Clicking this button will buy 1 hour of Speed Boost. */
+/* Label on a button. Clicking this button will buy 1 hour of Speed Boost. Translate number as well. */
 "SPEED_BOOST_1HR" = "1 hora";
 
-/* Label on a button. Clicking this button will buy 2 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 2 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_2HR" = "2 horas";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_3HR" = "3 hours";
 
-/* Label on a button. Clicking this button will buy 4 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 4 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_4HR" = "4 horas";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_5HR" = "5 hours";
 
-/* Label on a button. Clicking this button will buy 6 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 6 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_6HR" = "6 horas";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_7HR" = "7 hours";
 
-/* Label on a button. Clicking this button will buy 8 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 8 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_8HR" = "8 horas";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_9HR" = "9 hours";
 
 /*[UNTRANSLATED] Do not transliterate 'Speed Boost'. 'Speed Boost' is a product that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */

--- a/Shared/Strings/pt-PT.lproj/Localizable.strings
+++ b/Shared/Strings/pt-PT.lproj/Localizable.strings
@@ -142,8 +142,8 @@
 /*[UNTRANSLATED] Do not translate or transliterate 'PsiCash'. Informs the user that they must sign up for a PsiCash account or log in to their PsiCash account in order to user PsiCash features. */
 "LOG_IN_OR_SIGNUP_TO_CONTINUE" = "Log in or create account to continue using PsiCash";
 
-/* Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
-"LOG_OUT_ANY_WAY_BUTTON_TITLE" = "Logout anyway";
+/*[UNTRANSLATED] Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
+"LOG_OUT_ANY_WAY_BUTTON_TITLE_2" = "Log out anyway";
 
 /* Title of the button that lets users log out of their account */
 "LOG_OUT_BUTTON_TITLE_2" = "Terminar sessão";
@@ -346,7 +346,7 @@
 /*[UNTRANSLATED] Message when the user has made a purchase, and paid successfully, however the transaction is not complete yet and is pending verification */
 "PSICASH_WAIT_TRANSACTION_VERIFIED" = "Please wait while your transaction is being verified";
 
-/*[UNTRANSLATED] Alert message informing user that a Psip */
+/*[UNTRANSLATED] Alert message informing user that a Psiphon connection is required */
 "PSIPHON_CONNECTION_REQUIRED" = "Psiphon Connection Required";
 
 /*[UNTRANSLATED] Shown when user is not connected to Psiphon network. Do not translate or transliterate 'Psiphon' */
@@ -403,31 +403,31 @@
 /*[UNTRANSLATED] Do not transliterate 'Speed Boost'. 'Speed Boost' is a reward that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */
 "SPEED_BOOST" = "Speed Boost";
 
-/* Label on a button. Clicking this button will buy 1 hour of Speed Boost. */
+/* Label on a button. Clicking this button will buy 1 hour of Speed Boost. Translate number as well. */
 "SPEED_BOOST_1HR" = "1 hora";
 
-/* Label on a button. Clicking this button will buy 2 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 2 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_2HR" = "2 horas";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_3HR" = "3 hours";
 
-/* Label on a button. Clicking this button will buy 4 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 4 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_4HR" = "4 horas";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_5HR" = "5 hours";
 
-/* Label on a button. Clicking this button will buy 6 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 6 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_6HR" = "6 horas";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_7HR" = "7 hours";
 
-/* Label on a button. Clicking this button will buy 8 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 8 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_8HR" = "8 horas";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_9HR" = "9 hours";
 
 /*[UNTRANSLATED] Do not transliterate 'Speed Boost'. 'Speed Boost' is a product that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */

--- a/Shared/Strings/ru.lproj/Localizable.strings
+++ b/Shared/Strings/ru.lproj/Localizable.strings
@@ -142,8 +142,8 @@
 /*[UNTRANSLATED] Do not translate or transliterate 'PsiCash'. Informs the user that they must sign up for a PsiCash account or log in to their PsiCash account in order to user PsiCash features. */
 "LOG_IN_OR_SIGNUP_TO_CONTINUE" = "Log in or create account to continue using PsiCash";
 
-/* Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
-"LOG_OUT_ANY_WAY_BUTTON_TITLE" = "Logout anyway";
+/*[UNTRANSLATED] Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
+"LOG_OUT_ANY_WAY_BUTTON_TITLE_2" = "Log out anyway";
 
 /* Title of the button that lets users log out of their account */
 "LOG_OUT_BUTTON_TITLE_2" = "Выход";
@@ -346,7 +346,7 @@
 /* Message when the user has made a purchase, and paid successfully, however the transaction is not complete yet and is pending verification */
 "PSICASH_WAIT_TRANSACTION_VERIFIED" = "Пожалуйста, подождите окончания проверки транзакции";
 
-/* Alert message informing user that a Psip */
+/* Alert message informing user that a Psiphon connection is required */
 "PSIPHON_CONNECTION_REQUIRED" = "Требуется соединение Psiphon";
 
 /* Shown when user is not connected to Psiphon network. Do not translate or transliterate 'Psiphon' */
@@ -403,31 +403,31 @@
 /* Do not transliterate 'Speed Boost'. 'Speed Boost' is a reward that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */
 "SPEED_BOOST" = "Турбоскорость";
 
-/* Label on a button. Clicking this button will buy 1 hour of Speed Boost. */
+/* Label on a button. Clicking this button will buy 1 hour of Speed Boost. Translate number as well. */
 "SPEED_BOOST_1HR" = "1 час";
 
-/* Label on a button. Clicking this button will buy 2 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 2 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_2HR" = "2 часа";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_3HR" = "3 hours";
 
-/* Label on a button. Clicking this button will buy 4 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 4 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_4HR" = "4 часа";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_5HR" = "5 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 6 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 6 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_6HR" = "6 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_7HR" = "7 hours";
 
-/* Label on a button. Clicking this button will buy 8 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 8 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_8HR" = "8 часов";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_9HR" = "9 hours";
 
 /* Do not transliterate 'Speed Boost'. 'Speed Boost' is a product that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */

--- a/Shared/Strings/sw.lproj/Localizable.strings
+++ b/Shared/Strings/sw.lproj/Localizable.strings
@@ -142,8 +142,8 @@
 /*[UNTRANSLATED] Do not translate or transliterate 'PsiCash'. Informs the user that they must sign up for a PsiCash account or log in to their PsiCash account in order to user PsiCash features. */
 "LOG_IN_OR_SIGNUP_TO_CONTINUE" = "Log in or create account to continue using PsiCash";
 
-/* Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
-"LOG_OUT_ANY_WAY_BUTTON_TITLE" = "Logout anyway";
+/*[UNTRANSLATED] Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
+"LOG_OUT_ANY_WAY_BUTTON_TITLE_2" = "Log out anyway";
 
 /* Title of the button that lets users log out of their account */
 "LOG_OUT_BUTTON_TITLE_2" = "Ingia nje ";
@@ -346,7 +346,7 @@
 /* Message when the user has made a purchase, and paid successfully, however the transaction is not complete yet and is pending verification */
 "PSICASH_WAIT_TRANSACTION_VERIFIED" = "Tafadhali subiri wakati shunghuli zako zimethibitishwa";
 
-/* Alert message informing user that a Psip */
+/* Alert message informing user that a Psiphon connection is required */
 "PSIPHON_CONNECTION_REQUIRED" = "Psiphon inahitaji kuunganishwa";
 
 /* Shown when user is not connected to Psiphon network. Do not translate or transliterate 'Psiphon' */
@@ -403,31 +403,31 @@
 /* Do not transliterate 'Speed Boost'. 'Speed Boost' is a reward that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */
 "SPEED_BOOST" = "Kuongeza kasi";
 
-/* Label on a button. Clicking this button will buy 1 hour of Speed Boost. */
+/* Label on a button. Clicking this button will buy 1 hour of Speed Boost. Translate number as well. */
 "SPEED_BOOST_1HR" = "Lisaa1";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 2 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 2 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_2HR" = "2 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_3HR" = "3 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 4 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 4 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_4HR" = "4 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_5HR" = "5 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 6 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 6 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_6HR" = "6 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_7HR" = "7 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 8 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 8 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_8HR" = "8 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_9HR" = "9 hours";
 
 /* Do not transliterate 'Speed Boost'. 'Speed Boost' is a product that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */

--- a/Shared/Strings/tg.lproj/Localizable.strings
+++ b/Shared/Strings/tg.lproj/Localizable.strings
@@ -142,8 +142,8 @@
 /*[UNTRANSLATED] Do not translate or transliterate 'PsiCash'. Informs the user that they must sign up for a PsiCash account or log in to their PsiCash account in order to user PsiCash features. */
 "LOG_IN_OR_SIGNUP_TO_CONTINUE" = "Log in or create account to continue using PsiCash";
 
-/* Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
-"LOG_OUT_ANY_WAY_BUTTON_TITLE" = "Logout anyway";
+/*[UNTRANSLATED] Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
+"LOG_OUT_ANY_WAY_BUTTON_TITLE_2" = "Log out anyway";
 
 /*[UNTRANSLATED] Title of the button that lets users log out of their account */
 "LOG_OUT_BUTTON_TITLE_2" = "Log out";
@@ -346,7 +346,7 @@
 /*[UNTRANSLATED] Message when the user has made a purchase, and paid successfully, however the transaction is not complete yet and is pending verification */
 "PSICASH_WAIT_TRANSACTION_VERIFIED" = "Please wait while your transaction is being verified";
 
-/*[UNTRANSLATED] Alert message informing user that a Psip */
+/*[UNTRANSLATED] Alert message informing user that a Psiphon connection is required */
 "PSIPHON_CONNECTION_REQUIRED" = "Psiphon Connection Required";
 
 /*[UNTRANSLATED] Shown when user is not connected to Psiphon network. Do not translate or transliterate 'Psiphon' */
@@ -403,31 +403,31 @@
 /*[UNTRANSLATED] Do not transliterate 'Speed Boost'. 'Speed Boost' is a reward that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */
 "SPEED_BOOST" = "Speed Boost";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 1 hour of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 1 hour of Speed Boost. Translate number as well. */
 "SPEED_BOOST_1HR" = "1 hour";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 2 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 2 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_2HR" = "2 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_3HR" = "3 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 4 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 4 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_4HR" = "4 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_5HR" = "5 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 6 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 6 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_6HR" = "6 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_7HR" = "7 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 8 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 8 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_8HR" = "8 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_9HR" = "9 hours";
 
 /*[UNTRANSLATED] Do not transliterate 'Speed Boost'. 'Speed Boost' is a product that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */

--- a/Shared/Strings/th.lproj/Localizable.strings
+++ b/Shared/Strings/th.lproj/Localizable.strings
@@ -142,8 +142,8 @@
 /*[UNTRANSLATED] Do not translate or transliterate 'PsiCash'. Informs the user that they must sign up for a PsiCash account or log in to their PsiCash account in order to user PsiCash features. */
 "LOG_IN_OR_SIGNUP_TO_CONTINUE" = "Log in or create account to continue using PsiCash";
 
-/* Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
-"LOG_OUT_ANY_WAY_BUTTON_TITLE" = "Logout anyway";
+/*[UNTRANSLATED] Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
+"LOG_OUT_ANY_WAY_BUTTON_TITLE_2" = "Log out anyway";
 
 /* Title of the button that lets users log out of their account */
 "LOG_OUT_BUTTON_TITLE_2" = "ออกจากระบบ";
@@ -346,7 +346,7 @@
 /*[UNTRANSLATED] Message when the user has made a purchase, and paid successfully, however the transaction is not complete yet and is pending verification */
 "PSICASH_WAIT_TRANSACTION_VERIFIED" = "Please wait while your transaction is being verified";
 
-/*[UNTRANSLATED] Alert message informing user that a Psip */
+/*[UNTRANSLATED] Alert message informing user that a Psiphon connection is required */
 "PSIPHON_CONNECTION_REQUIRED" = "Psiphon Connection Required";
 
 /*[UNTRANSLATED] Shown when user is not connected to Psiphon network. Do not translate or transliterate 'Psiphon' */
@@ -403,31 +403,31 @@
 /*[UNTRANSLATED] Do not transliterate 'Speed Boost'. 'Speed Boost' is a reward that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */
 "SPEED_BOOST" = "Speed Boost";
 
-/* Label on a button. Clicking this button will buy 1 hour of Speed Boost. */
+/* Label on a button. Clicking this button will buy 1 hour of Speed Boost. Translate number as well. */
 "SPEED_BOOST_1HR" = "1 ชั่วโมง";
 
-/* Label on a button. Clicking this button will buy 2 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 2 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_2HR" = "2 ชั่วโมง";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_3HR" = "3 hours";
 
-/* Label on a button. Clicking this button will buy 4 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 4 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_4HR" = "4 ชั่วโมง";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_5HR" = "5 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 6 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 6 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_6HR" = "6 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_7HR" = "7 hours";
 
-/* Label on a button. Clicking this button will buy 8 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 8 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_8HR" = "8 ชั่วโมง";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_9HR" = "9 hours";
 
 /*[UNTRANSLATED] Do not transliterate 'Speed Boost'. 'Speed Boost' is a product that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */

--- a/Shared/Strings/ti.lproj/Localizable.strings
+++ b/Shared/Strings/ti.lproj/Localizable.strings
@@ -142,8 +142,8 @@
 /*[UNTRANSLATED] Do not translate or transliterate 'PsiCash'. Informs the user that they must sign up for a PsiCash account or log in to their PsiCash account in order to user PsiCash features. */
 "LOG_IN_OR_SIGNUP_TO_CONTINUE" = "Log in or create account to continue using PsiCash";
 
-/* Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
-"LOG_OUT_ANY_WAY_BUTTON_TITLE" = "Logout anyway";
+/*[UNTRANSLATED] Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
+"LOG_OUT_ANY_WAY_BUTTON_TITLE_2" = "Log out anyway";
 
 /*[UNTRANSLATED] Title of the button that lets users log out of their account */
 "LOG_OUT_BUTTON_TITLE_2" = "Log out";
@@ -346,7 +346,7 @@
 /*[UNTRANSLATED] Message when the user has made a purchase, and paid successfully, however the transaction is not complete yet and is pending verification */
 "PSICASH_WAIT_TRANSACTION_VERIFIED" = "Please wait while your transaction is being verified";
 
-/*[UNTRANSLATED] Alert message informing user that a Psip */
+/*[UNTRANSLATED] Alert message informing user that a Psiphon connection is required */
 "PSIPHON_CONNECTION_REQUIRED" = "Psiphon Connection Required";
 
 /*[UNTRANSLATED] Shown when user is not connected to Psiphon network. Do not translate or transliterate 'Psiphon' */
@@ -403,31 +403,31 @@
 /*[UNTRANSLATED] Do not transliterate 'Speed Boost'. 'Speed Boost' is a reward that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */
 "SPEED_BOOST" = "Speed Boost";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 1 hour of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 1 hour of Speed Boost. Translate number as well. */
 "SPEED_BOOST_1HR" = "1 hour";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 2 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 2 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_2HR" = "2 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_3HR" = "3 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 4 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 4 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_4HR" = "4 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_5HR" = "5 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 6 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 6 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_6HR" = "6 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_7HR" = "7 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 8 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 8 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_8HR" = "8 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_9HR" = "9 hours";
 
 /*[UNTRANSLATED] Do not transliterate 'Speed Boost'. 'Speed Boost' is a product that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */

--- a/Shared/Strings/tk.lproj/Localizable.strings
+++ b/Shared/Strings/tk.lproj/Localizable.strings
@@ -142,8 +142,8 @@
 /*[UNTRANSLATED] Do not translate or transliterate 'PsiCash'. Informs the user that they must sign up for a PsiCash account or log in to their PsiCash account in order to user PsiCash features. */
 "LOG_IN_OR_SIGNUP_TO_CONTINUE" = "Log in or create account to continue using PsiCash";
 
-/* Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
-"LOG_OUT_ANY_WAY_BUTTON_TITLE" = "Logout anyway";
+/*[UNTRANSLATED] Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
+"LOG_OUT_ANY_WAY_BUTTON_TITLE_2" = "Log out anyway";
 
 /*[UNTRANSLATED] Title of the button that lets users log out of their account */
 "LOG_OUT_BUTTON_TITLE_2" = "Log out";
@@ -346,7 +346,7 @@
 /*[UNTRANSLATED] Message when the user has made a purchase, and paid successfully, however the transaction is not complete yet and is pending verification */
 "PSICASH_WAIT_TRANSACTION_VERIFIED" = "Please wait while your transaction is being verified";
 
-/*[UNTRANSLATED] Alert message informing user that a Psip */
+/*[UNTRANSLATED] Alert message informing user that a Psiphon connection is required */
 "PSIPHON_CONNECTION_REQUIRED" = "Psiphon Connection Required";
 
 /*[UNTRANSLATED] Shown when user is not connected to Psiphon network. Do not translate or transliterate 'Psiphon' */
@@ -403,31 +403,31 @@
 /*[UNTRANSLATED] Do not transliterate 'Speed Boost'. 'Speed Boost' is a reward that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */
 "SPEED_BOOST" = "Speed Boost";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 1 hour of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 1 hour of Speed Boost. Translate number as well. */
 "SPEED_BOOST_1HR" = "1 hour";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 2 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 2 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_2HR" = "2 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_3HR" = "3 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 4 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 4 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_4HR" = "4 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_5HR" = "5 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 6 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 6 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_6HR" = "6 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_7HR" = "7 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 8 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 8 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_8HR" = "8 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_9HR" = "9 hours";
 
 /*[UNTRANSLATED] Do not transliterate 'Speed Boost'. 'Speed Boost' is a product that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */

--- a/Shared/Strings/tr.lproj/Localizable.strings
+++ b/Shared/Strings/tr.lproj/Localizable.strings
@@ -44,7 +44,7 @@
 "CONNECT_BUTTON" = "Bağlantı kur";
 
 /* Action button title, that when pressed connects the user to Psiphon network. */
-"CONNECT_BUTTON_TITLE" = "Bağlan";
+"CONNECT_BUTTON_TITLE" = "Bağlantı kur";
 
 /* Text shown to the user telling them to connect to 'Psiphon', to finish their unfinished transaction. Do not translate or transliterate 'Psiphon'. */
 "CONNECT_TO_FINISH_PSICASH_TRANSACTION" = "İşleminizi tamamlamak için Psiphon ile bağlantı kurun";
@@ -55,8 +55,8 @@
 /* User must connect to 'Psiphon' in order to use 'Speed Boost' product. Do not translate or transliterate 'Psiphon'. Do not transliterate 'Speed Boost'. 'Speed Boost' is a reward that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */
 "CONNECT_TO_USE_SPEED_BOOST" = "Speed Boost kullanmak için Psiphon bağlantısı kurun";
 
-/*[UNTRANSLATED] Label text shown to user when the VPN is connecting to a Psiphon server. Do not translate or transliterate 'Psiphon' */
-"CONNECTING_TO_PSIPHON" = "Connecting to Psiphon";
+/* Label text shown to user when the VPN is connecting to a Psiphon server. Do not translate or transliterate 'Psiphon' */
+"CONNECTING_TO_PSIPHON" = "Psiphon bağlantısı kuruluyor";
 
 /* Alert dialog message informing the user that the settings file in the app is corrupt, and that they can potentially fix this issue by re-installing the app. */
 "CORRUPT_SETTINGS_MESSAGE" = "Uygulama ayarları dosyanız bozulmuş gibi görünüyor. Dosyayı onarmak için uygulamayı yeniden kurmayı deneyin.";
@@ -64,8 +64,8 @@
 /* Button label that lets users create a new account. */
 "CREATE_ACCOUNT_BUTTON_TITLE" = "Hesap açın";
 
-/*[UNTRANSLATED] Body of a modal dialog that appears when the user tries to buy PsiCash with real money but doens't have an account. The word 'PsiCash' must not be translated or transliterated. */
-"CREATE_PSICASH_ACCOUNT_BODY_2" = "We strongly encourage you to make a PsiCash account before buying PsiCash. Having an account allows you to share your balance between devices and protect your purchases.\n\nIMPORTANT: Without an account your PsiCash will not be preserved if you uninstall Psiphon.";
+/* Body of a modal dialog that appears when the user tries to buy PsiCash with real money but doens't have an account. The word 'PsiCash' must not be translated or transliterated. */
+"CREATE_PSICASH_ACCOUNT_BODY_2" = "PsiCash satın almadan önce bir PsiCash hesabı oluşturmanızı önemle öneririz. Bir hesap açarak, bakiyenizi aygıtlarınız arasında paylalabilir ve satın aldığınız PsiCash bakiyenizi koruyabilirsiniz.\n\nÖNEMLİ: Bir hesabınız olmadan, Psiphon uygulamasını kaldırırsanız PsiCash bakiyenizi kaybedersiniz.";
 
 /* Button in the modal dialog encouraging users to create an account when they attempt to buy PsiCash with real money without one. If they click this button, they will continue on to the PsiCash store. */
 "CREATE_PSICASH_ACCOUNT_CONTINUE_BUTTON" = "Hesap açmadan ilerle";
@@ -110,7 +110,7 @@
 "FEEDBACK_UPLOAD_SUCCESSFUL_TITLE" = "Psiphon gelişimine katkıda bulunduğunuz için teşekkür ederiz!";
 
 /* Button title that lets users reset their password if they forgot their account's password. */
-"FORGOT_PASSWORD" = "Parolayı mı unuttunuz?";
+"FORGOT_PASSWORD" = "Parolanızı mı unuttunuz?";
 
 /* Button title for a product that is free. There is no cost or payment associated. */
 "FREE_PSICASH_COIN" = "Ücretsiz";
@@ -122,7 +122,7 @@
 "INCORRECT_USERNAME_OR_PASSWORD" = "Yazdığınız kullanıcı adı ya da parola hatalı.";
 
 /* User does not have sufficient 'PsiCash' balance. PsiCash is a type of credit. Do not translate or transliterate 'PsiCash'. */
-"INSUFFICIENT_PSICASH_BALANCE" = "PsiCash birikimi yetersiz";
+"INSUFFICIENT_PSICASH_BALANCE" = "PsiCash bakiyesi yetersiz";
 
 /* External link to the license page. Please update this with the correct language specific link (if available) e.g. https://psiphon.ca/fr/license.html for french. */
 "LICENSE_PAGE_URL" = "https://psiphon.ca/tr/license.html";
@@ -130,29 +130,29 @@
 /* Text displayed while app loads */
 "LOADING" = "Yükleniyor...";
 
-/*[UNTRANSLATED] Message shown when a resource (online or offline) fails to load. */
-"LOADING_FAILED" = "Loading failed";
+/* Message shown when a resource (online or offline) fails to load. */
+"LOADING_FAILED" = "Yüklenemedi";
 
 /* Title on a button that lets users login to their account with the username and password they have entered. */
 "LOG_IN_BUTTON_TITLE" = "Oturum aç";
 
-/*[UNTRANSLATED] Message title informing the user that they must sign up for an account or log in to their account */
-"LOG_IN_OR_SIGN_UP" = "Log in or sign up";
+/* Message title informing the user that they must sign up for an account or log in to their account */
+"LOG_IN_OR_SIGN_UP" = "Oturum ya da hesap açın";
 
-/*[UNTRANSLATED] Do not translate or transliterate 'PsiCash'. Informs the user that they must sign up for a PsiCash account or log in to their PsiCash account in order to user PsiCash features. */
-"LOG_IN_OR_SIGNUP_TO_CONTINUE" = "Log in or create account to continue using PsiCash";
+/* Do not translate or transliterate 'PsiCash'. Informs the user that they must sign up for a PsiCash account or log in to their PsiCash account in order to user PsiCash features. */
+"LOG_IN_OR_SIGNUP_TO_CONTINUE" = "PsiCash kullanmayı sürdürmek için oturum ya da hesap açın";
 
 /* Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
-"LOG_OUT_ANY_WAY_BUTTON_TITLE" = "Hayır oturumu kapat";
+"LOG_OUT_ANY_WAY_BUTTON_TITLE_2" = "Oturumu yine de kapat";
 
 /* Title of the button that lets users log out of their account */
 "LOG_OUT_BUTTON_TITLE_2" = "Oturumu kapat";
 
-/*[UNTRANSLATED] Label indicating to the user that they are logging into their PsiCash account. Use ellipses if it makes sense. */
-"LOGGING_IN_ELLIPSES" = "Logging in ...";
+/* Label indicating to the user that they are logging into their PsiCash account. Use ellipses if it makes sense. */
+"LOGGING_IN_ELLIPSES" = "Oturum açılıyor ...";
 
-/*[UNTRANSLATED] Label indicating to the user that they are logging out of their PsiCash account. Use ellipses if it makes sense. */
-"LOGGING_OUT_ELLIPSES" = "Logging out ...";
+/* Label indicating to the user that they are logging out of their PsiCash account. Use ellipses if it makes sense. */
+"LOGGING_OUT_ELLIPSES" = "Oturum kapatılıyor ...";
 
 /* Button title that takes user to the next page */
 "NEXT_PAGE_BUTTON_TITLE" = "Sonraki";
@@ -187,8 +187,8 @@
 /* Alert message informing the user they should open the app to finish connecting to the VPN. DO NOT translate 'Psiphon'. */
 "OPEN_PSIPHON_APP" = "Lütfen bağlantıyı tamamlamak için Psiphon uygulamasını açın.";
 
-/*[UNTRANSLATED] Capitalize where it makes sense. Label visually separating Sign up section and sign in section of the app. */
-"OR_SIGNUP_SIGNIN" = "OR";
+/* Capitalize where it makes sense. Label visually separating Sign up section and sign in section of the app. */
+"OR_SIGNUP_SIGNIN" = "YA DA";
 
 /* Text field label where users can enter their account's password */
 "PASSWORD_TEXT_FIELD" = "Parola";
@@ -259,20 +259,20 @@
 /* Message shown when products available for purchase could not be retrieved. */
 "PRODUCT_LIST_COULD_NOT_BE_RETRIEVED" = "Ürün listesi alınamadı";
 
-/*[UNTRANSLATED] Text for a link displayed when the user does not have a PsiCash account. It encourages them to make one. The word 'PsiCash' must not be translated or transliterated. */
-"PROTECT_YOUR_PURCHASES" = "Protect Your Purchases";
+/* Text for a link displayed when the user does not have a PsiCash account. It encourages them to make one. The word 'PsiCash' must not be translated or transliterated. */
+"PROTECT_YOUR_PURCHASES" = "Satın almalarınızı koruyun";
 
 /* Do not translate or transliterate 'PsiCash'. Header of a box providing context that the actions inside the box are related to PsiCash accounts. */
 "PSICASH_ACCOUNT" = "PsiCash hesabı";
 
-/*[UNTRANSLATED] Do not translate or transliterate 'PsiCash'. Alert message asking user if they are sure they would like to logout of their PsiCash account */
-"PSICASH_ACCOUNT_LOGOUT_CHECK_PROMPT" = "Are you sure you want to log out of your PsiCash account?";
+/* Do not translate or transliterate 'PsiCash'. Alert message asking user if they are sure they would like to logout of their PsiCash account */
+"PSICASH_ACCOUNT_LOGOUT_CHECK_PROMPT" = "PsiCash hesabınızın oturumunu kapatmak istediğinize emin misiniz?";
 
 /* An alert shown when the user logs out of their PsiCash account. The word 'PsiCash' must not be translated or transliterated. */
 "PSICASH_ACCOUNT_LOGOUT_COMPLETE_TITLE" = "PsiCash hesabının oturumu kapatıldı.";
 
-/*[UNTRANSLATED] Body of modal dialog shown when the user attempts to log out of their PsiCash account and an unexpected error occurs. Please don't modify the link URL. */
-"PSICASH_ACCOUNT_LOGOUT_FAILED_BODY" = "You logout attempt failed unexpectedly. Please try restarting the application.";
+/* Body of modal dialog shown when the user attempts to log out of their PsiCash account and an unexpected error occurs. Please don't modify the link URL. */
+"PSICASH_ACCOUNT_LOGOUT_FAILED_BODY" = "Oturumunuz kapatılamadı. Lütfen uygulamayı yeniden başlatmayı deneyin.";
 
 /* Header of a modal dialog that appears when the user tries to log out of their PsiCash account. The word 'PsiCash' must not be translated or transliterated. */
 "PSICASH_ACCOUNT_LOGOUT_TITLE" = "PsiCash hesabı oturumunu kapat";
@@ -280,20 +280,20 @@
 /* Button title that opens 'PsiCash' account management. */
 "PSICASH_ACCOUNT_MANAGEMENT_2" = "Hesap yönetimi";
 
-/*[UNTRANSLATED] An alert shown when the user's PsiCash account tokens expire. This is a normal occurrence (once per year), and the user needs to log into their PsiCash account again to continue to use it. The word 'PsiCash' must not be translated or transliterated. */
-"PSICASH_ACCOUNT_TOKENS_EXPIRED_BODY_2" = "Your PsiCash login has expired. Please log back in.";
+/* An alert shown when the user's PsiCash account tokens expire. This is a normal occurrence (once per year), and the user needs to log into their PsiCash account again to continue to use it. The word 'PsiCash' must not be translated or transliterated. */
+"PSICASH_ACCOUNT_TOKENS_EXPIRED_BODY_2" = "PsiCash oturumunuz zaman aşımına uğramış. Lütfen yeniden oturum açın.";
 
 /* Body text of a modal dialog shown when a PsiCash login succeeds. There is a fixed number of times that a user can merge a pre-account balance into a PsiCash account. This message indicates that the user has hit that limit and the merge that occurred is the last one allowed. The word 'PsiCash' must not be translated or transliterated. */
 "PSICASH_ACCOUNTS_LAST_MERGE_WARNING_BODY" = "PsiCash hesabınıza oturum açtınız. Bu aygıttaki bakiyeniz hesabınıza aktarıldı. Ancak bu bakiye aktarımı işlemi son kez yapıldı.";
 
 /* PsiCash is a type of credit. Do not translate or transliterate 'PsiCash'. Text shown next to the user's PsiCash balance (a numerical value). Keep colon if appropriate. */
-"PSICASH_BALANCE" = "PsiCash birikimi:";
+"PSICASH_BALANCE" = "PsiCash bakiyesi:";
 
 /* Body text of a modal dialog shown when a PsiCash account login fails due to a 'bad request' error. The word 'PsiCash' must not be translated or transliterated. */
 "PSICASH_LOGIN_BAD_REQUEST_ERROR_BODY" = "PsiCash sunucusu oturum alma isteğinin geçersiz olduğunu bildirdi. Lütfen bir süre sonra yeniden deneyin.";
 
 /* Body text of a modal dialog shown when a PsiCash login fails without a specific reason. The word 'PsiCash' must not be translated or transliterated. */
-"PSICASH_LOGIN_CATASTROPHIC_ERROR_BODY" = "PsiCash oturum açma girişiminiz beklenmedik şekilde sonlandı.";
+"PSICASH_LOGIN_CATASTROPHIC_ERROR_BODY" = "PsiCash oturumu açma girişiminiz beklenmedik şekilde sonlandı.";
 
 /* Title of modal dialog shown when the PsiCash account login attempt fails for some reason. Text within the modal will explain why. The word 'PsiCash' must not be translated or transliterated. */
 "PSICASH_LOGIN_FAILED_TITLE" = "PsiCash oturumu açılamadı";
@@ -305,13 +305,13 @@
 "PSICASH_LOGIN_SUCCESS_TITLE" = "PsiCash oturumu açıldı";
 
 /* Body of a modal dialog that appears when the user tries to log out of thier PsiCash account while not currently connected to the Psiphon network. We don't allow PsiCash network requests when not connected, so only an inferior localy-only logout is available. 'Psiphon' must not be translated/transliterated. The word 'PsiCash' must not be translated or transliterated. */
-"PSICASH_LOGOUT_OFFLINE_BODY" = "Psiphon ağına bağlanmak, PsiCash oturumunun daha güvenli şekilde kapatılmasını sağlar. Oturumu kapatmadan önce bağlantı kurmak ister misiniz?";
+"PSICASH_LOGOUT_OFFLINE_BODY" = "Psiphon ağıyla bağlantı kurmak, PsiCash oturumunun daha güvenli şekilde kapatılmasını sağlar. Oturumu kapatmadan önce bağlantı kurmak ister misiniz?";
 
 /* Body text of a modal dialog shown when the user tries to use (spend, buy, etc.) PsiCash, if they not currently connected. 'Use' here means buy, spend, or otherwise interact with. 'Psiphon' must not be translated/transliterated. 'PsiCash' must not be translated/transliterated. */
 "PSICASH_MUST_BE_CONNECTED" = "PsiCash kullanabilmeniz için, Psiphon ağına bağlı olmalısınız.";
 
-/*[UNTRANSLATED] PsiCash in-app purchase disclaimer that appears on the bottom of the screen where users can buy different amounts of PsiCash from the PlayStore.  Do not translate or transliterate terms PsiCash */
-"PSICASH_NON_ACCOUNT_SCREEN_NOTICE" = "IMPORTANT: Your PsiCash will not be preserved if you uninstall Psiphon, unless you have created a PsiCash account and are logged into your PsiCash account.";
+/* PsiCash in-app purchase disclaimer that appears on the bottom of the screen where users can buy different amounts of PsiCash from the PlayStore.  Do not translate or transliterate terms PsiCash */
+"PSICASH_NON_ACCOUNT_SCREEN_NOTICE" = "ÖNEMLİ: Bir PsiCash hesabı oluşturup PsiCash hesabınızla oturum açmadıkça, Psiphon uygulamasını kaldırdığınızda PsiCash bakiyenizi kaybedersiniz.";
 
 /* Alert error message informing user that their Speed Boost purchase request failed because they attempted to buy a product that is no longer available and that they should try updating or reinstalling the app. 'Speed Boost' is a reward that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */
 "PSICASH_SPEED_BOOST_PRODUCT_NOT_FOUND_MESSAGE" = "Speed Boost ürünü bulunamadı. Uygulamanız eski olabilir. Lütfen güncellemeleri denetleyin.";
@@ -322,8 +322,8 @@
 /* Heading for an information section explaining that there are port and speed restrictions when the user doesn't have Speed Boost active. */
 "PSICASH_SPEED_PORT_LIMITS_HEAD" = "Hız ve kapı kısıtlamaları";
 
-/*[UNTRANSLATED] A description message to the premium user (a user with a subscription) when they are trying to navigate to PsiCash and Speed Boost screen. 'Speed Boost' is a reward that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. Do not translate or transliterate words PsiCash or Psiphon */
-"PSICASH_SUBSCRIPTION_PREMIUM_ACCESS_BODY" = "Your Psiphon subscription already gives you always-on Speed Boost, so there is no reason to buy more. Your PsiCash balance will be retained should you ever decide to cancel your subscription.\n\nYou can still access your PsiCash account from the settings menu.";
+/* A description message to the premium user (a user with a subscription) when they are trying to navigate to PsiCash and Speed Boost screen. 'Speed Boost' is a reward that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. Do not translate or transliterate words PsiCash or Psiphon */
+"PSICASH_SUBSCRIPTION_PREMIUM_ACCESS_BODY" = "Psiphon aboneliğiniz size sürekli Speed Boost kullanımı sağlıyor. Bu yüzden daha fazlasını satın almanıza gerek yok. Aboneliğinizi sonlandırmak isteyebilirsiniz diye PsiCash bakiyeniz tutulacak.\n\nPsiCash hesabınıza ayarlar menüsünden ulaşabilirsiniz.";
 
 /* A title message to the premium user (a user with a subscription when they are trying to navigate to PsiCash and Speed Boost screen. Do not translate or transliterate words PsiCash or Psiphon */
 "PSICASH_SUBSCRIPTION_PREMIUM_ACCESS_TITLE" = "Psiphon aboneliğiniz size ayrıcalıklı erişim sunuyor!";
@@ -346,14 +346,14 @@
 /* Message when the user has made a purchase, and paid successfully, however the transaction is not complete yet and is pending verification */
 "PSICASH_WAIT_TRANSACTION_VERIFIED" = "Lütfen işleminiz doğrulanırken bekleyin";
 
-/* Alert message informing user that a Psip */
+/* Alert message informing user that a Psiphon connection is required */
 "PSIPHON_CONNECTION_REQUIRED" = "Psiphon bağlantısı gerekli";
 
 /* Shown when user is not connected to Psiphon network. Do not translate or transliterate 'Psiphon' */
 "PSIPHON_IS_NOT_CONNECTED" = "Psiphon bağlantısı yok";
 
-/*[UNTRANSLATED] Alert message that the users purchases have been restored successfully */
-"PURCHASES_RESTORED_SUCCESSFULLY" = "Purchases restored successfully";
+/* Alert message that the users purchases have been restored successfully */
+"PURCHASES_RESTORED_SUCCESSFULLY" = "Satın almalarınız geri yüklendi";
 
 /* Shown when the user is purchasing PsiCash. PsiCash is a type of credit. Do not translate or transliterate 'PsiCash'. Including ellipses '…' if appropriate. */
 "PURCHASING_PSICASH" = "PsiCash satın alınıyor…";
@@ -370,8 +370,8 @@
 /* Point in a list of scenarios where the user should try refreshing their app receipt to restore an existing subscription */
 "REFRESH_APP_RECEIPT_BUTTON_DESCRIPTION_POINT_2" = "Bu aygıt üzerinden satın aldığınız bir aboneliği göremezsiniz";
 
-/*[UNTRANSLATED] Button that restores users previous purchases */
-"RESTORE_PURCHASES" = "Restore purchases";
+/* Button that restores users previous purchases */
+"RESTORE_PURCHASES" = "Satın almaları geri yükle";
 
 /* Button which, when pressed, attempts to restore any existing subscriptions the user has purchased */
 "RESTORE_SUBSCRIPTION_BUTTON" = "Aboneliği geri yükle";
@@ -403,31 +403,31 @@
 /*[UNTRANSLATED] Do not transliterate 'Speed Boost'. 'Speed Boost' is a reward that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */
 "SPEED_BOOST" = "Speed Boost";
 
-/* Label on a button. Clicking this button will buy 1 hour of Speed Boost. */
+/* Label on a button. Clicking this button will buy 1 hour of Speed Boost. Translate number as well. */
 "SPEED_BOOST_1HR" = "1 saat";
 
-/* Label on a button. Clicking this button will buy 2 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 2 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_2HR" = "2 saat";
 
-/* Label on a button. Clicking this button will buy 3 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 3 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_3HR" = "3 saat";
 
-/* Label on a button. Clicking this button will buy 4 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 4 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_4HR" = "4 saat";
 
-/* Label on a button. Clicking this button will buy 5 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 5 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_5HR" = "5 saat";
 
-/* Label on a button. Clicking this button will buy 6 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 6 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_6HR" = "6 saat";
 
-/* Label on a button. Clicking this button will buy 7 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 7 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_7HR" = "7 saat";
 
-/* Label on a button. Clicking this button will buy 8 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 8 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_8HR" = "8 saat";
 
-/* Label on a button. Clicking this button will buy 9 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 9 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_9HR" = "9 saat";
 
 /* Do not transliterate 'Speed Boost'. 'Speed Boost' is a product that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */

--- a/Shared/Strings/uk.lproj/Localizable.strings
+++ b/Shared/Strings/uk.lproj/Localizable.strings
@@ -142,8 +142,8 @@
 /*[UNTRANSLATED] Do not translate or transliterate 'PsiCash'. Informs the user that they must sign up for a PsiCash account or log in to their PsiCash account in order to user PsiCash features. */
 "LOG_IN_OR_SIGNUP_TO_CONTINUE" = "Log in or create account to continue using PsiCash";
 
-/* Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
-"LOG_OUT_ANY_WAY_BUTTON_TITLE" = "Logout anyway";
+/*[UNTRANSLATED] Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
+"LOG_OUT_ANY_WAY_BUTTON_TITLE_2" = "Log out anyway";
 
 /*[UNTRANSLATED] Title of the button that lets users log out of their account */
 "LOG_OUT_BUTTON_TITLE_2" = "Log out";
@@ -346,7 +346,7 @@
 /*[UNTRANSLATED] Message when the user has made a purchase, and paid successfully, however the transaction is not complete yet and is pending verification */
 "PSICASH_WAIT_TRANSACTION_VERIFIED" = "Please wait while your transaction is being verified";
 
-/* Alert message informing user that a Psip */
+/* Alert message informing user that a Psiphon connection is required */
 "PSIPHON_CONNECTION_REQUIRED" = "Psiphon з'єднання необхідне";
 
 /*[UNTRANSLATED] Shown when user is not connected to Psiphon network. Do not translate or transliterate 'Psiphon' */
@@ -403,31 +403,31 @@
 /* Do not transliterate 'Speed Boost'. 'Speed Boost' is a reward that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */
 "SPEED_BOOST" = "Прискорення швидкості";
 
-/* Label on a button. Clicking this button will buy 1 hour of Speed Boost. */
+/* Label on a button. Clicking this button will buy 1 hour of Speed Boost. Translate number as well. */
 "SPEED_BOOST_1HR" = "1 година";
 
-/* Label on a button. Clicking this button will buy 2 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 2 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_2HR" = "2 години";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_3HR" = "3 hours";
 
-/* Label on a button. Clicking this button will buy 4 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 4 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_4HR" = "4 години";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_5HR" = "5 hours";
 
-/* Label on a button. Clicking this button will buy 6 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 6 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_6HR" = "6 годин";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_7HR" = "7 hours";
 
-/* Label on a button. Clicking this button will buy 8 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 8 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_8HR" = "8 годин";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_9HR" = "9 hours";
 
 /*[UNTRANSLATED] Do not transliterate 'Speed Boost'. 'Speed Boost' is a product that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */

--- a/Shared/Strings/uz.lproj/Localizable.strings
+++ b/Shared/Strings/uz.lproj/Localizable.strings
@@ -142,8 +142,8 @@
 /*[UNTRANSLATED] Do not translate or transliterate 'PsiCash'. Informs the user that they must sign up for a PsiCash account or log in to their PsiCash account in order to user PsiCash features. */
 "LOG_IN_OR_SIGNUP_TO_CONTINUE" = "Log in or create account to continue using PsiCash";
 
-/* Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
-"LOG_OUT_ANY_WAY_BUTTON_TITLE" = "Logout anyway";
+/*[UNTRANSLATED] Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
+"LOG_OUT_ANY_WAY_BUTTON_TITLE_2" = "Log out anyway";
 
 /*[UNTRANSLATED] Title of the button that lets users log out of their account */
 "LOG_OUT_BUTTON_TITLE_2" = "Log out";
@@ -346,7 +346,7 @@
 /*[UNTRANSLATED] Message when the user has made a purchase, and paid successfully, however the transaction is not complete yet and is pending verification */
 "PSICASH_WAIT_TRANSACTION_VERIFIED" = "Please wait while your transaction is being verified";
 
-/*[UNTRANSLATED] Alert message informing user that a Psip */
+/*[UNTRANSLATED] Alert message informing user that a Psiphon connection is required */
 "PSIPHON_CONNECTION_REQUIRED" = "Psiphon Connection Required";
 
 /*[UNTRANSLATED] Shown when user is not connected to Psiphon network. Do not translate or transliterate 'Psiphon' */
@@ -403,31 +403,31 @@
 /*[UNTRANSLATED] Do not transliterate 'Speed Boost'. 'Speed Boost' is a reward that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */
 "SPEED_BOOST" = "Speed Boost";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 1 hour of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 1 hour of Speed Boost. Translate number as well. */
 "SPEED_BOOST_1HR" = "1 hour";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 2 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 2 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_2HR" = "2 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_3HR" = "3 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 4 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 4 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_4HR" = "4 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_5HR" = "5 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 6 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 6 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_6HR" = "6 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_7HR" = "7 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 8 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 8 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_8HR" = "8 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_9HR" = "9 hours";
 
 /*[UNTRANSLATED] Do not transliterate 'Speed Boost'. 'Speed Boost' is a product that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */

--- a/Shared/Strings/vi.lproj/Localizable.strings
+++ b/Shared/Strings/vi.lproj/Localizable.strings
@@ -142,8 +142,8 @@
 /*[UNTRANSLATED] Do not translate or transliterate 'PsiCash'. Informs the user that they must sign up for a PsiCash account or log in to their PsiCash account in order to user PsiCash features. */
 "LOG_IN_OR_SIGNUP_TO_CONTINUE" = "Log in or create account to continue using PsiCash";
 
-/* Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
-"LOG_OUT_ANY_WAY_BUTTON_TITLE" = "Logout anyway";
+/*[UNTRANSLATED] Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
+"LOG_OUT_ANY_WAY_BUTTON_TITLE_2" = "Log out anyway";
 
 /*[UNTRANSLATED] Title of the button that lets users log out of their account */
 "LOG_OUT_BUTTON_TITLE_2" = "Log out";
@@ -346,7 +346,7 @@
 /*[UNTRANSLATED] Message when the user has made a purchase, and paid successfully, however the transaction is not complete yet and is pending verification */
 "PSICASH_WAIT_TRANSACTION_VERIFIED" = "Please wait while your transaction is being verified";
 
-/*[UNTRANSLATED] Alert message informing user that a Psip */
+/*[UNTRANSLATED] Alert message informing user that a Psiphon connection is required */
 "PSIPHON_CONNECTION_REQUIRED" = "Psiphon Connection Required";
 
 /*[UNTRANSLATED] Shown when user is not connected to Psiphon network. Do not translate or transliterate 'Psiphon' */
@@ -403,31 +403,31 @@
 /* Do not transliterate 'Speed Boost'. 'Speed Boost' is a reward that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */
 "SPEED_BOOST" = "Tăng Tốc.";
 
-/* Label on a button. Clicking this button will buy 1 hour of Speed Boost. */
+/* Label on a button. Clicking this button will buy 1 hour of Speed Boost. Translate number as well. */
 "SPEED_BOOST_1HR" = "1 tiếng";
 
-/* Label on a button. Clicking this button will buy 2 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 2 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_2HR" = "2 tiếng";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_3HR" = "3 hours";
 
-/* Label on a button. Clicking this button will buy 4 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 4 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_4HR" = "4 tiếng";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_5HR" = "5 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 6 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 6 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_6HR" = "6 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_7HR" = "7 hours";
 
-/* Label on a button. Clicking this button will buy 8 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 8 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_8HR" = "8 tiếng";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_9HR" = "9 hours";
 
 /*[UNTRANSLATED] Do not transliterate 'Speed Boost'. 'Speed Boost' is a product that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */

--- a/Shared/Strings/zh-Hans.lproj/Localizable.strings
+++ b/Shared/Strings/zh-Hans.lproj/Localizable.strings
@@ -143,7 +143,7 @@
 "LOG_IN_OR_SIGNUP_TO_CONTINUE" = "Log in or create account to continue using PsiCash";
 
 /* Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
-"LOG_OUT_ANY_WAY_BUTTON_TITLE" = "Logout anyway";
+"LOG_OUT_ANY_WAY_BUTTON_TITLE_2" = "继续登出";
 
 /*[UNTRANSLATED] Title of the button that lets users log out of their account */
 "LOG_OUT_BUTTON_TITLE_2" = "Log out";
@@ -346,7 +346,7 @@
 /* Message when the user has made a purchase, and paid successfully, however the transaction is not complete yet and is pending verification */
 "PSICASH_WAIT_TRANSACTION_VERIFIED" = "请耐心等待您的交易验证";
 
-/* Alert message informing user that a Psip */
+/* Alert message informing user that a Psiphon connection is required */
 "PSIPHON_CONNECTION_REQUIRED" = "需要连接至赛风";
 
 /* Shown when user is not connected to Psiphon network. Do not translate or transliterate 'Psiphon' */
@@ -403,31 +403,31 @@
 /* Do not transliterate 'Speed Boost'. 'Speed Boost' is a reward that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */
 "SPEED_BOOST" = "加速";
 
-/* Label on a button. Clicking this button will buy 1 hour of Speed Boost. */
+/* Label on a button. Clicking this button will buy 1 hour of Speed Boost. Translate number as well. */
 "SPEED_BOOST_1HR" = "1 小时";
 
-/* Label on a button. Clicking this button will buy 2 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 2 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_2HR" = "2小时";
 
-/* Label on a button. Clicking this button will buy 3 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 3 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_3HR" = "3小时";
 
-/* Label on a button. Clicking this button will buy 4 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 4 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_4HR" = "4小时";
 
-/* Label on a button. Clicking this button will buy 5 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 5 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_5HR" = "5小时";
 
-/* Label on a button. Clicking this button will buy 6 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 6 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_6HR" = "6小时";
 
-/* Label on a button. Clicking this button will buy 7 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 7 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_7HR" = "7小时";
 
-/* Label on a button. Clicking this button will buy 8 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 8 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_8HR" = "8小时";
 
-/* Label on a button. Clicking this button will buy 9 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 9 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_9HR" = "9小时";
 
 /* Do not transliterate 'Speed Boost'. 'Speed Boost' is a product that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */

--- a/Shared/Strings/zh-Hant.lproj/Localizable.strings
+++ b/Shared/Strings/zh-Hant.lproj/Localizable.strings
@@ -142,8 +142,8 @@
 /*[UNTRANSLATED] Do not translate or transliterate 'PsiCash'. Informs the user that they must sign up for a PsiCash account or log in to their PsiCash account in order to user PsiCash features. */
 "LOG_IN_OR_SIGNUP_TO_CONTINUE" = "Log in or create account to continue using PsiCash";
 
-/* Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
-"LOG_OUT_ANY_WAY_BUTTON_TITLE" = "Logout anyway";
+/*[UNTRANSLATED] Button in the modal dialog shown to users when they attempt to log out of their PsiCash account with no active Psiphon tunnel. Clicking this button will cause a local-only logout to be performed. */
+"LOG_OUT_ANY_WAY_BUTTON_TITLE_2" = "Log out anyway";
 
 /* Title of the button that lets users log out of their account */
 "LOG_OUT_BUTTON_TITLE_2" = "登出";
@@ -346,7 +346,7 @@
 /*[UNTRANSLATED] Message when the user has made a purchase, and paid successfully, however the transaction is not complete yet and is pending verification */
 "PSICASH_WAIT_TRANSACTION_VERIFIED" = "Please wait while your transaction is being verified";
 
-/*[UNTRANSLATED] Alert message informing user that a Psip */
+/*[UNTRANSLATED] Alert message informing user that a Psiphon connection is required */
 "PSIPHON_CONNECTION_REQUIRED" = "Psiphon Connection Required";
 
 /*[UNTRANSLATED] Shown when user is not connected to Psiphon network. Do not translate or transliterate 'Psiphon' */
@@ -403,31 +403,31 @@
 /* Do not transliterate 'Speed Boost'. 'Speed Boost' is a reward that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */
 "SPEED_BOOST" = "加速版 Speed Boost";
 
-/* Label on a button. Clicking this button will buy 1 hour of Speed Boost. */
+/* Label on a button. Clicking this button will buy 1 hour of Speed Boost. Translate number as well. */
 "SPEED_BOOST_1HR" = "1 小時";
 
-/* Label on a button. Clicking this button will buy 2 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 2 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_2HR" = "2小時";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 3 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_3HR" = "3 hours";
 
-/* Label on a button. Clicking this button will buy 4 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 4 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_4HR" = "4小時";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 5 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_5HR" = "5 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 6 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 6 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_6HR" = "6 hours";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 7 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_7HR" = "7 hours";
 
-/* Label on a button. Clicking this button will buy 8 hours of Speed Boost. */
+/* Label on a button. Clicking this button will buy 8 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_8HR" = "8小時";
 
-/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. */
+/*[UNTRANSLATED] Label on a button. Clicking this button will buy 9 hours of Speed Boost. Translate number as well. */
 "SPEED_BOOST_9HR" = "9 hours";
 
 /* Do not transliterate 'Speed Boost'. 'Speed Boost' is a product that can be purchased with PsiCash credit. It provides unlimited network connection speed through Psiphon. Other words that can be used to help with translation are: 'turbo' (like cars), 'accelerate', 'warp speed', 'blast off', or anything that indicates a fast or unrestricted speed. */


### PR DESCRIPTION
- Fixed target="_blank" links not opened
- Fixed showing untunneled message when there are no Speed Boost products