### PR TITLE
Fixed stuck loading screen on PsiCash library initialization failure

### DIFF
--- a/PsiApi/Sources/PsiCashClient/PsiCashEffectsProtocol.swift
+++ b/PsiApi/Sources/PsiCashClient/PsiCashEffectsProtocol.swift
@@ -81,7 +81,7 @@ public protocol PsiCashEffectsProtocol {
         tunnelConnectionRefSignal: SignalProducer<TunnelConnection?, Never>
     ) -> Effect<PsiCashInitResult>
     
-    func libData() -> PsiCashLibData
+    func libData() -> Result<PsiCashLibData, ErrorRepr>
     
     func refreshState(
         priceClasses: [PsiCashTransactionClass],

--- a/PsiApi/Sources/PsiCashClient/PsiCashState.swift
+++ b/PsiApi/Sources/PsiCashClient/PsiCashState.swift
@@ -24,6 +24,8 @@ import PsiApi
 
 public struct PsiCashState: Equatable {
     
+    public typealias PsiCashLibState = Result<PsiCashLibData, ErrorRepr>?
+    
     // Failure type matches PsiCashEffects.PsiCashRefreshResult.Failure
     public typealias PendingRefresh =
         PendingResult<Utilities.Unit,
@@ -49,14 +51,14 @@ public struct PsiCashState: Equatable {
     public var purchasing: PsiCashPurchasingState
     
     /// Representation of PsiCash data held by PsiCash library.
-    /// `nil` if library is not initialized
-    public var libData: PsiCashLibData?
+    /// If `nil`, PsiCash library is not initialized yet.
+    public var libData: PsiCashLibState
     
     public var pendingAccountLoginLogout: PendingAccountLoginLogoutEvent?
     public var pendingPsiCashRefresh: PendingRefresh
     
     
-    public init(purchasing: PsiCashPurchasingState, libData: PsiCashLibData? = nil, pendingAccountLoginLogout: PsiCashState.PendingAccountLoginLogoutEvent? = nil, pendingPsiCashRefresh: PsiCashState.PendingRefresh) {
+    public init(purchasing: PsiCashPurchasingState, libData: Result<PsiCashLibData, ErrorRepr>? = nil, pendingAccountLoginLogout: PsiCashState.PendingAccountLoginLogoutEvent? = nil, pendingPsiCashRefresh: PsiCashState.PendingRefresh) {
         self.purchasing = purchasing
         self.libData = libData
         self.pendingAccountLoginLogout = pendingAccountLoginLogout
@@ -112,7 +114,7 @@ extension PsiCashState {
         _ dateCompare: DateCompare
     ) -> PurchasedExpirableProduct<SpeedBoostProduct>? {
         
-        let activeSpeedBoosts = libData?.activePurchases.partitionResults().successes
+        let activeSpeedBoosts = libData?.successToOptional()?.activePurchases.partitionResults().successes
             .compactMap(\.speedBoost)
             .filter { !$0.transaction.isExpired(dateCompare) }
         

--- a/Psiphon/AppAction+ValuePaths.swift
+++ b/Psiphon/AppAction+ValuePaths.swift
@@ -217,7 +217,7 @@ extension AppState {
             IAPReducerState(
                 iap: self.iapState,
                 psiCashBalance: self.psiCashBalance,
-                psiCashAccountType: self.psiCashState.libData?.accountType
+                psiCashAccountType: self.psiCashState.libData?.successToOptional()?.accountType
             )
         }
         set {
@@ -307,7 +307,7 @@ extension AppState {
             MainViewReducerState(
                 mainView: self.mainView,
                 subscriptionState: self.subscription,
-                psiCashAccountType: self.psiCashState.libData?.accountType,
+                psiCashAccountType: self.psiCashState.libData?.successToOptional()?.accountType,
                 appLifecycle: self.appDelegateState.appLifecycle,
                 tunnelConnectedStatus: self.vpnState.value.providerVPNStatus.tunneled
             )

--- a/Psiphon/AppState.swift
+++ b/Psiphon/AppState.swift
@@ -290,7 +290,9 @@ func makeEnvironment(
         notifier: NotifierObjC(notifier:Notifier.sharedInstance()),
         internetReachabilityStatusSignal: store.$value.signalProducer.map(\.internetReachability.networkStatus),
         tunnelStatusSignal: tunnelStatusSignal,
-        psiCashAccountTypeSignal: store.$value.signalProducer.map(\.psiCashState.libData?.accountType),
+        psiCashAccountTypeSignal: store.$value.signalProducer.map {
+            $0.psiCashState.libData?.successToOptional()?.accountType
+        },
         tunnelConnectionRefSignal: store.$value.signalProducer.map(\.tunnelConnection),
         subscriptionStatusSignal: store.$value.signalProducer.map(\.subscription.status),
         urlHandler: .default(),
@@ -447,7 +449,7 @@ func makeEnvironment(
                 store: store.projection(
                     value: {
                         PsiCashAccountViewController.ReaderState(
-                            psiCashAccountType: $0.psiCashState.libData?.accountType,
+                            psiCashAccountType: $0.psiCashState.libData?.successToOptional()?.accountType,
                             pendingAccountLoginLogout: $0.psiCashState.pendingAccountLoginLogout
                         )
                     },

--- a/Psiphon/PsiCashEffects.swift
+++ b/Psiphon/PsiCashEffects.swift
@@ -285,8 +285,12 @@ final class PsiCashEffects: PsiCashEffectsProtocol {
         }
     }
     
-    func libData() -> PsiCashLibData {
-        return self.psiCashLib.dataModel
+    func libData() -> Result<PsiCashLibData, ErrorRepr> {
+        if self.psiCashLib.initialized {
+            return .success(self.psiCashLib.dataModel)
+        } else {
+            return .failure(ErrorRepr(repr: "PsiCash lib is not initialized"))
+        }
     }
     
     func refreshState(

--- a/Psiphon/Settings/SettingsViewModel.swift
+++ b/Psiphon/Settings/SettingsViewModel.swift
@@ -26,7 +26,7 @@ import PsiCashClient
 struct SettingsViewModel: Equatable {
     let receiptRefreshState: ReceiptState.ReceiptRefreshState
     let subscriptionState: SubscriptionStatus
-    let psiCashAccountType: PsiCashAccountType?
+    let psiCashLib: PsiCashState.PsiCashLibState
     let isLoggingOut: Bool
     let vpnStatus: VPNStatus
 }
@@ -52,10 +52,19 @@ struct SettingsViewModel: Equatable {
         }
     }
     
+    @objc var isPsiCashInitialized: Bool {
+        switch model.psiCashLib {
+        case .none, .failure(_):
+            return false
+        case .success(_):
+            return true
+        }
+    }
+    
     @objc var isPsiCashAccountLoggedIn: Bool {
-        switch model.psiCashAccountType {
+        switch model.psiCashLib?.successToOptional()?.accountType {
         case .none:
-            // PsiCash lib not loaded.
+            // PsiCash lib not initialized.
             return false
         case .account(loggedIn: true):
             return true

--- a/Psiphon/SwiftDelegate.swift
+++ b/Psiphon/SwiftDelegate.swift
@@ -676,7 +676,9 @@ extension SwiftDelegate: SwiftBridgeDelegate {
                 with: self.store.$value.signalProducer.map(\.psiCashBalanceViewModel).skipRepeats()
             )
             .combineLatest(
-                with: self.store.$value.signalProducer.map(\.psiCashState.libData?.accountType).skipRepeats()
+                with: self.store.$value.signalProducer .map {
+                        $0.psiCashState.libData?.successToOptional()?.accountType
+                    }
             )
             .startWithValues { [unowned objcBridge] (tuple: ((SpeedBoostButton.SpeedBoostButtonViewModel, PsiCashBalanceViewModel), PsiCashAccountType?)) in
                 
@@ -713,7 +715,7 @@ extension SwiftDelegate: SwiftBridgeDelegate {
             self.store.$value.signalProducer.map(\.appReceipt.remoteReceiptRefreshState)
                 .skipRepeats(),
             self.store.$value.signalProducer.map(\.subscription.status).skipRepeats(),
-            self.store.$value.signalProducer.map(\.psiCashState.libData?.accountType).skipRepeats(),
+            self.store.$value.signalProducer.map(\.psiCashState.libData).skipRepeats(),
             self.store.$value.signalProducer.map(\.psiCashState.isLoggingInOrOut),
             self.store.$value.signalProducer.map(\.vpnState.value.vpnStatus).skipRepeats()
         ).map {
@@ -721,7 +723,7 @@ extension SwiftDelegate: SwiftBridgeDelegate {
             SettingsViewModel(
                 receiptRefreshState: $0.0,
                 subscriptionState: $0.1,
-                psiCashAccountType: $0.2,
+                psiCashLib: $0.2,
                 isLoggingOut: $0.3 == .logout,
                 vpnStatus: $0.4
             )
@@ -857,7 +859,7 @@ extension SwiftDelegate: SwiftBridgeDelegate {
             .compactMap { psiCashState -> _TokensExpiredData? in
                 
                 // Removes PsiCash library non-initialized value (literal `nil`) from signal.
-                guard let accountType = psiCashState.libData?.accountType else {
+                guard let accountType = psiCashState.libData?.successToOptional()?.accountType else {
                     return nil
                 }
                 

--- a/Psiphon/UITestAppState.swift
+++ b/Psiphon/UITestAppState.swift
@@ -42,7 +42,7 @@ func makeUITestAppState(embeddedServerEntriesFile: String) -> AppState {
     // NOTE: Assumes the price of each SB product is hrs * 100 PsiCash.
     let allSpeedBoostProducts = SpeedBoostDistinguisher.allCases.map { sbDistinguisher -> PsiCashPurchasableType in
         let sbProduct = SpeedBoostProduct(distinguisher: sbDistinguisher.rawValue)!
-        let price = PsiCashAmount(nanoPsi: Int64(sbDistinguisher.hours * 100_000_000_000))
+        let price = PsiCashAmount(nanoPsi: Int64(sbDistinguisher.hours) * 100_000_000_000)
         return .speedBoost(.init(product: sbProduct, price: price))
     }
     
@@ -76,12 +76,12 @@ func makeUITestAppState(embeddedServerEntriesFile: String) -> AppState {
         ),
         psiCashState: PsiCashState(
             purchasing: .none,
-            libData: PsiCashLibData(
+            libData: .success(PsiCashLibData(
                 accountType: .account(loggedIn: true) /* User is logged in */,
                 accountName: "open_internet_123" /* PsiCash Account username */,
                 balance: psiCashBalance,
                 availableProducts: allSpeedBoostProducts.map(Result.success),
-                activePurchases: []),
+                activePurchases: [])),
             pendingAccountLoginLogout: .none,
             pendingPsiCashRefresh: .completed(.success(.unit))
         ),

--- a/Psiphon/UserStrings.swift
+++ b/Psiphon/UserStrings.swift
@@ -478,6 +478,12 @@ extension UserStrings {
                                  comment: "Subtitle shown when the current operation failed, asking the user to try again at a later time.")
     }
     
+    static func PsiCash_lib_init_failed_send_feedback() -> String {
+        return NSLocalizedString("PSICASH_LIB_INIT_FAILED_SEND_FEEDBACK", tableName: nil, bundle: Bundle.main,
+                                 value: "PsiCash failed to load.\n\nIf this problem persists, please send a feedback.",
+                                 comment: "Subtitle of an error message shown when the PsiCash feature is unavailable, asking the user to send us a feedback if this problem persists.")
+    }
+    
     static func Something_went_wrong_try_again_and_send_feedback() -> String {
         return NSLocalizedString("PLEASE_TRY_AGAIN_LATER_AND_SEND_FEEDBACK", tableName: nil, bundle: Bundle.main,
                                  value: "Something went wrong, please try again later.\n\nIf this problem persists, please send a feedback.",

--- a/Psiphon/View/PsiCashView/PsiCashMessageView.swift
+++ b/Psiphon/View/PsiCashView/PsiCashMessageView.swift
@@ -22,6 +22,7 @@ import UIKit
 struct PsiCashMessageView: ViewBuilder {
 
     enum Message {
+        case psiCashLibFailedInit
         case pendingPsiCashVerification
         case speedBoostAlreadyActive
         case userSubscribed
@@ -32,8 +33,6 @@ struct PsiCashMessageView: ViewBuilder {
         case psiCashAccountsLoggingIn
         case psiCashAccountsLoggingOut
         case noSpeedBoostProducts
-        // PsiCash library no loaded message.
-        case psiCashNotLoaded
     }
 
     func build(_ container: UIView?) -> ImmutableBindableViewable<Message, UIView> {
@@ -86,6 +85,12 @@ struct PsiCashMessageView: ViewBuilder {
         return .init(viewable: wrapper) { [imageView, title, subtitle] _ -> ((PsiCashMessageView.Message) -> Void) in
             return { [imageView, title, subtitle] msg in
                 switch msg {
+                case .psiCashLibFailedInit:
+                    imageView.image =  UIImage(named: "PsiCashCoinCloud")!
+                    title.text = ""
+                    subtitle.text = UserStrings.PsiCash_lib_init_failed_send_feedback()
+                    subtitle.textAlignment = .center
+                    
                 case .pendingPsiCashVerification:
                     imageView.image = UIImage(named: "PsiCashPendingTransaction")
                     title.text = UserStrings.PsiCash_transaction_pending()
@@ -143,12 +148,6 @@ struct PsiCashMessageView: ViewBuilder {
                     title.text = UserStrings.PsiCash_unavailable()
                     subtitle.text = UserStrings.Something_went_wrong_try_again_and_send_feedback()
                     subtitle.textAlignment = .center
-                    
-                case .psiCashNotLoaded:
-                    imageView.image = UIImage(named: "PsiCashCoinCloud")!
-                    title.text = ""
-                    subtitle.text = ""
-                    
                 }
             }
         }

--- a/Psiphon/View/PsiCashView/PsiCashWidgetView.swift
+++ b/Psiphon/View/PsiCashView/PsiCashWidgetView.swift
@@ -119,14 +119,17 @@ import PsiCashClient
         speedBoostButton.bind(newValue.speedBoostButtonModel)
         
         switch newValue.accountType {
-        case .none, .noTokens, .tracker, .account(loggedIn: false):
+        case .noTokens, .tracker, .account(loggedIn: false):
             // Shows psiCashAccountButton, if not displayed already.
             if psiCashAccountButton.isHidden {
                 topRowHStack.addArrangedSubview(psiCashAccountButton)
                 psiCashAccountButton.isHidden = false
             }
             
-        case .account(loggedIn: true):
+        case .none, .account(loggedIn: true):
+            // PsiCashAccountType is expected to be nil only if PsiCash library fails initialize,
+            // or is still being initialized (although Loading screen is expected to be displayed,
+            // while the library is initializing.)
             // Hides psiCashAccountButton, if not removed already.
             if !psiCashAccountButton.isHidden {
                 topRowHStack.removeArrangedSubview(psiCashAccountButton)

--- a/Psiphon/ViewControllers/PsiCashViewController.swift
+++ b/Psiphon/ViewControllers/PsiCashViewController.swift
@@ -217,8 +217,8 @@ final class PsiCashViewController: ReactiveViewController {
             return
         }
         
-        guard let psiCashLibData = observed.readerState.psiCash.libData else {
-            guard self.updateUIStateHelper(.psiCashNotLoaded) else { fatalError() }
+        guard case let .success(psiCashLibData) = observed.readerState.psiCash.libData else {
+            guard self.updateUIStateHelper(.psiCashLibFailedInit) else { fatalError() }
             return
         }
         
@@ -302,7 +302,7 @@ final class PsiCashViewController: ReactiveViewController {
         self.balanceViewWrapper.bind(observed.readerState.psiCashBalanceViewModel)
         
         // Sets account username if availalbe
-        if let accountName = observed.readerState.psiCash.libData?.accountUsername {
+        if let accountName = psiCashLibData.accountUsername {
             self.accountNameViewWrapper.bind(accountName)
         }
         
@@ -493,8 +493,7 @@ final class PsiCashViewController: ReactiveViewController {
     
     /// An incomplete representation of the UI state, used only by the `updateUIStateHelper(_:)` method.
     enum _UIState: Equatable {
-        // PsiCash library not loaded yet.
-        case psiCashNotLoaded
+        case psiCashLibFailedInit
         case unknownSubscription
         case subscribed(PsiCashAccountType)
         case notSubscribed(TunnelConnectedStatus, PsiCashAccountType, PsiCashState.LoginLogoutPendingValue?)
@@ -508,14 +507,14 @@ final class PsiCashViewController: ReactiveViewController {
         
         switch state {
             
-        case .psiCashNotLoaded:
+        case .psiCashLibFailedInit:
             self.accountNameViewWrapper.view.isHidden = true
             self.balanceViewWrapper.view.isHidden = true
             self.tabControl.view.isHidden = true
             self.signupOrLogInView.isHidden = true
             
             self.containerView.bind(
-                .left(.right(.right(.right(.right(.psiCashNotLoaded)))))
+                .left(.right(.right(.right(.right(.psiCashLibFailedInit)))))
             )
             
             return true

--- a/Psiphon/ViewControllers/SettingsViewController.m
+++ b/Psiphon/ViewControllers/SettingsViewController.m
@@ -144,9 +144,10 @@ NSString * const SettingspsiCashAccountLoginCellSpecifierKey = @"settingsLoginPs
     }
     
     // PsiCash Login button:
-    // - Shown when not logged in (no tokens, trackers, logged out state)
+    // - Shown when not logged in (no tokens, trackers, logged out state),
+    //   or when PsiCash lib did not initialize successfully.
     // - Not allowed when disconnected (button disabled, not hidden).
-    if (self.viewModel.isPsiCashAccountLoggedIn == TRUE) {
+    if (self.viewModel.isPsiCashInitialized == FALSE || self.viewModel.isPsiCashAccountLoggedIn == TRUE) {
         [hiddenKeys addObject:SettingspsiCashAccountLoginCellSpecifierKey];
     } else {
         [hiddenKeys removeObject:SettingspsiCashAccountLoginCellSpecifierKey];

--- a/Shared/Strings/en.lproj/Localizable.strings
+++ b/Shared/Strings/en.lproj/Localizable.strings
@@ -543,6 +543,9 @@
 /* PsiCash is a type of credit. Do not translate or transliterate 'PsiCash'. Text shown next to the user's PsiCash balance (a numerical value). Keep colon if appropriate. */
 "PSICASH_BALANCE" = "PsiCash Balance:";
 
+/* Subtitle of an error message shown when the PsiCash feature is unavailable, asking the user to send us a feedback if this problem persists. */
+"PSICASH_LIB_INIT_FAILED_SEND_FEEDBACK" = "PsiCash failed to load.\n\nIf this problem persists, please send a feedback.";
+
 /* Body text of a modal dialog shown when a PsiCash account login fails due to a 'bad request' error. The word 'PsiCash' must not be translated or transliterated. */
 "PSICASH_LOGIN_BAD_REQUEST_ERROR_BODY" = "The PsiCash server indicated that the login request was invalid. Please try again later.";
 


### PR DESCRIPTION
Modifications:
- Distinguished between PsiCash not initialized state, and PsiCash
  initialization failure in PsiCashState.
- Guarded PsiCash login on PsiCash library initialization
- Removed PsiCash login UI elements if initialization had failed
- Added more specific user-facing message if PsiCash lib failed to init