### PR TITLE
Set excludeLocalNetworks to always true

### DIFF
--- a/PsiApi/Sources/PsiApi/TunnelProviderManager.swift
+++ b/PsiApi/Sources/PsiApi/TunnelProviderManager.swift
@@ -314,6 +314,9 @@ public final class PsiphonTPM: TunnelProviderManager {
             
             if #available(iOS 14.0, *) {
                 self.wrappedManager.protocolConfiguration!.includeAllNetworks = true
+                
+                // Excludes local network on both iOS and macOS running on Apple Silicon.
+                self.wrappedManager.protocolConfiguration!.excludeLocalNetworks = true
             }
             
         case .stopVPN:


### PR DESCRIPTION
The default value of excludeLocalNetworks is YES for iOS,
and NO for macOS.

This commit sets the value to always be YES for all platforms
running this code.