### PR TITLE
Fix purchased SB distinguishers not parsed

### DIFF
--- a/PsiApi/Sources/PsiCashClient/HardCodedValues.swift
+++ b/PsiApi/Sources/PsiCashClient/HardCodedValues.swift
@@ -24,6 +24,14 @@ public enum SpeedBoostDistinguisher: String, CaseIterable {
     
     // Raw values must match distinguisher values set by the PsiCash server.
     case hr1 = "1hr"
+    case hr2 = "2hr"
+    case hr3 = "3hr"
+    case hr4 = "4hr"
+    case hr5 = "5hr"
+    case hr6 = "6hr"
+    case hr7 = "7hr"
+    case hr8 = "8hr"
+    case hr9 = "9hr"
     case hr24 = "24hr"
     case day7 = "7day"
     case day31 = "31day"
@@ -36,9 +44,32 @@ extension SpeedBoostDistinguisher {
     public var hours: Int {
         switch self {
         case .hr1: return 1
+        case .hr2: return 2
+        case .hr3: return 3
+        case .hr4: return 4
+        case .hr5: return 5
+        case .hr6: return 6
+        case .hr7: return 7
+        case .hr8: return 8
+        case .hr9: return 9
         case .hr24: return 24
         case .day7: return 24 * 7
         case .day31: return 24 * 31
+        }
+    }
+    
+}
+
+extension SpeedBoostDistinguisher {
+    
+    /// True if Speed Boost with this distinguisher is available for sale on this client.
+    public var availableForSale: Bool {
+        switch self {
+        case .hr1, .hr24, .day7, .day31:
+            return true
+                
+        case .hr2, .hr3, .hr4, .hr5, .hr6, .hr7, .hr8, .hr9:
+            return false
         }
     }
     

--- a/Psiphon/PsiCash/PsiCashLib.swift
+++ b/Psiphon/PsiCash/PsiCashLib.swift
@@ -826,6 +826,14 @@ extension SpeedBoostProduct {
     var localizedString: String {
         switch self.distinguisher {
         case .hr1: return UserStrings.Speed_boost_1_hour()
+        case .hr2: return UserStrings.Speed_boost_2_hours()
+        case .hr3: return UserStrings.Speed_boost_3_hours()
+        case .hr4: return UserStrings.Speed_boost_4_hours()
+        case .hr5: return UserStrings.Speed_boost_5_hours()
+        case .hr6: return UserStrings.Speed_boost_6_hours()
+        case .hr7: return UserStrings.Speed_boost_7_hours()
+        case .hr8: return UserStrings.Speed_boost_8_hours()
+        case .hr9: return UserStrings.Speed_boost_9_hours()
         case .hr24: return UserStrings.Speed_boost_24_hour()
         case .day7: return UserStrings.Speed_boost_7_day()
         case .day31: return UserStrings.Speed_boost_31_day()

--- a/Psiphon/View/PsiCashView/SpeedBoostPurchaseTable.swift
+++ b/Psiphon/View/PsiCashView/SpeedBoostPurchaseTable.swift
@@ -419,6 +419,14 @@ enum SpeedBoostPurchaseBackground: String, CaseIterable {
     static func background(speedBoostDistinguisher: SpeedBoostDistinguisher) -> Self {
         switch speedBoostDistinguisher {
         case .hr1: return .orange
+        case .hr2: return .pink
+        case .hr3: return .purple
+        case .hr4: return .darkBlue
+        case .hr5: return .blue
+        case .hr6: return .green
+        case .hr7: return .lightOrange
+        case .hr8: return .yellow
+        case .hr9: return .limeGreen
         case .hr24: return .pink
         case .day7: return .purple
         case .day31: return .darkBlue

--- a/Psiphon/ViewControllers/PsiCashStoreViewController.swift
+++ b/Psiphon/ViewControllers/PsiCashStoreViewController.swift
@@ -452,6 +452,7 @@ final class PsiCashStoreViewController: ReactiveViewController {
                         psiCashLibData.purchasePrices.compactMap {
                             $0.successToOptional()?.speedBoost
                         }
+                        .filter { $0.product.distinguisher.availableForSale }
                         .map { purchasable -> SpeedBoostPurchasableViewModel in
                             
                             let productTitle = purchasable.product.localizedString


### PR DESCRIPTION
* The available of a SB option is gated by `availableForSale` property on `SpeedBoostDistinguisher`.