### PR TITLE
Start VPN if last stop was reassertion timeout

### DIFF
--- a/PsiphonVPN/BasePacketTunnelProvider.h
+++ b/PsiphonVPN/BasePacketTunnelProvider.h
@@ -64,6 +64,10 @@ typedef NS_ENUM(NSInteger, ExtensionStartMethodEnum) {
     /*! @const ExtensionStartMethodOther The Network Extension process was either started by "Connect On Demand" rules,
         or by the user from system settings. */
     ExtensionStartMethodOther,
+    /*! @const ExtensionStartMethodOtherAfterSystemStop The Network Extension process was either started by
+        "Connect On Demand" rules, or by the user from system settings, and was last stopped by the system with
+        NEProviderStopReasonIdleTimeout or NEProviderStopReasonConnectionFailed. */
+    ExtensionStartMethodOtherAfterSystemStop,
 };
 
 #pragma mark - BasePacketTunnelProvider protocol

--- a/PsiphonVPN/PacketTunnelProvider.m
+++ b/PsiphonVPN/PacketTunnelProvider.m
@@ -261,16 +261,18 @@ typedef NS_ENUM(NSInteger, TunnelProviderState) {
     
     // Increments "VPN Session" number when the network extension is started
     // from the container or other methods.
-    // Note: This implies that network extension process start after a detected carsh
+    // Note: This implies that network extension process start after a detected crash
     //       or from boot do not increment the "VPN Session" number.
     if (self.extensionStartMethod == ExtensionStartMethodFromContainer ||
-        self.extensionStartMethod == ExtensionStartMethodOther) {
+        self.extensionStartMethod == ExtensionStartMethodOther ||
+        self.extensionStartMethod == ExtensionStartMethodOtherAfterSystemStop) {
         [self.sharedDB incrementVPNSessionNumber];
     }
 
     if (self.extensionStartMethod == ExtensionStartMethodFromContainer ||
         self.extensionStartMethod == ExtensionStartMethodFromBoot ||
         self.extensionStartMethod == ExtensionStartMethodFromCrash ||
+        self.extensionStartMethod == ExtensionStartMethodOtherAfterSystemStop ||
         hasSubscriptionAuth == TRUE) {
 
         [self.sharedDB setExtensionIsZombie:FALSE];
@@ -329,6 +331,8 @@ typedef NS_ENUM(NSInteger, TunnelProviderState) {
                                json:@{@"Event":@"Stop",
                                       @"StopReason": [PacketTunnelUtils textStopReason:reason],
                                       @"StopCode": @(reason)}];
+
+    [self.sharedDB setExtensionStopReason:reason];
 
     [self.psiphonTunnel stop];
 }

--- a/Shared/PsiphonDataSharedDB.h
+++ b/Shared/PsiphonDataSharedDB.h
@@ -42,6 +42,7 @@ extern UserDefaultsKey const _Nonnull TunnelStartTimeStringKey;
 extern UserDefaultsKey const _Nonnull TunnelSponsorIDStringKey;
 extern UserDefaultsKey const _Nonnull ServerTimestampStringKey;
 extern UserDefaultsKey const _Nonnull ExtensionIsZombieBoolKey;
+extern UserDefaultsKey const _Nonnull ExtensionStopReasonIntegerKey;
 extern UserDefaultsKey const _Nonnull ContainerForegroundStateBoolKey;
 extern UserDefaultsKey const _Nonnull ContainerTunnelIntentStatusIntKey;
 extern UserDefaultsKey const _Nonnull ExtensionDisallowedTrafficAlertWriteSeqIntKey;
@@ -216,7 +217,7 @@ The integer values are defined in `NEBridge.h` with prefix `TUNNEL_INTENT_`.
 - (BOOL)setCurrentSponsorId:(NSString *_Nullable)sponsorId;
 
 /**
- * @brief Sets server timestamp in shared NSSUserDefaults dictionary.
+ * @brief Sets server timestamp in shared NSUserDefaults dictionary.
  * @param timestamp from the handshake in RFC3339 format.
  * @return TRUE if change was persisted to disk successfully, FALSE otherwise.
  */
@@ -245,6 +246,23 @@ The integer values are defined in `NEBridge.h` with prefix `TUNNEL_INTENT_`.
  * Returns last value recorded by the extension with call to `setExtensionIsZombie:`.
  */
 - (BOOL)getExtensionIsZombie;
+
+#if TARGET_IS_EXTENSION
+/**
+ * @brief Sets extension stop reason in shared NSUserDefaults. Called by the extension when
+ * stopped.
+ * @param stopReason Provider stop reason. See NEProviderStopReason.
+ */
+- (void)setExtensionStopReason:(NSInteger)stopReason;
+
+/**
+ * @return Previously persisted NEProviderStopReason in shared NSUserDefaults, which is the
+ * reason the extension was last stopped. Returns 0 if the the extension has not been stopped yet,
+ * which is the same as NEProviderStopReasonNone; i.e. first run of the extension after as fresh
+ * install or a subsequent run if the extension continues to jetsam before it is stopped.
+ */
+- (NSInteger)getExtensionStopReason;
+#endif
 
 #if TARGET_IS_EXTENSION
 - (void)incrementDisallowedTrafficAlertWriteSequenceNum;

--- a/Shared/PsiphonDataSharedDB.m
+++ b/Shared/PsiphonDataSharedDB.m
@@ -46,6 +46,8 @@ UserDefaultsKey const ConstainerPurchaseRequiredVPNSessionHandledIntKey =
 
 UserDefaultsKey const ExtensionIsZombieBoolKey = @"extension_zombie";
 
+UserDefaultsKey const ExtensionStopReasonIntegerKey = @"extension_stop_reason";
+
 UserDefaultsKey const ContainerSharedDebugFlagsKey = @"SHARED_DEBUG_FLAGS";
 
 UserDefaultsKey const ContainerForegroundStateBoolKey = @"container_foreground_state_bool_key";
@@ -347,6 +349,14 @@ UserDefaultsKey const ContainerAppReceiptLatestSubscriptionExpiryDate_Legacy =
 
 - (BOOL)getExtensionIsZombie {
     return [sharedDefaults boolForKey:ExtensionIsZombieBoolKey];
+}
+
+- (void)setExtensionStopReason:(NSInteger)reason {
+    [sharedDefaults setInteger:reason forKey:ExtensionStopReasonIntegerKey];
+}
+
+- (NSInteger)getExtensionStopReason {
+    return [sharedDefaults integerForKey:ExtensionStopReasonIntegerKey];
 }
 
 - (void)incrementDisallowedTrafficAlertWriteSequenceNum {


### PR DESCRIPTION
NEProviderStopReason ConnectionFailed and IdleTimeout indicate that the extension was stopped because it was in the reasserting state for too long. After the extension is stopped with either reason, sometimes "Connect On Demand" rules bring the extension back up, which causes our code to put it into zombie mode if the user does not have an active authorization. Instead start the VPN.

Related https://forums.developer.apple.com/forums/thread/744949.